### PR TITLE
EC-CUBE 3.0.16 を追加

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
 
 env:
   # plugin code
@@ -24,9 +25,9 @@ env:
     # ec-cube 3.0.13
     - ECCUBE_VERSION=3.0.13 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
     - ECCUBE_VERSION=3.0.13 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
-    # ec-cube 3.0.15
-    - ECCUBE_VERSION=3.0.15 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
-    - ECCUBE_VERSION=3.0.15 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
+    # ec-cube 3.0.16
+    - ECCUBE_VERSION=3.0.16 DB=mysql USER=root DBNAME=myapp_test DBPASS=' ' DBUSER=root
+    - ECCUBE_VERSION=3.0.16 DB=pgsql USER=postgres DBNAME=myapp_test DBPASS=password DBUSER=postgres
 
 matrix:
   fast_finish: true
@@ -44,6 +45,8 @@ matrix:
     - php: 5.6
       env: ECCUBE_VERSION=master DB=sqlite
     - php: 7.0
+      env: ECCUBE_VERSION=master DB=sqlite
+    - php: 7.1
       env: ECCUBE_VERSION=master DB=sqlite
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,30 +37,35 @@ install:
   - cd %BASE_DIR%
   # checkout version
   #- sh -c "if [ ! '%ECCUBE_VERSION%' = 'master' ]; then  git checkout -b %ECCUBE_VERSION% refs/tags/%ECCUBE_VERSION%; fi"
+  # see https://github.com/phpmd/phpmd/blob/master/appveyor.yml#L10-L13
+  - cinst -y OpenSSL.Light --version 1.1.1
+  - SET PATH=C:\Program Files\OpenSSL;%PATH%
+  - sc config wuauserv start= auto
+  - net start wuauserv
   # Set MySQL.
   - cp tests/my.cnf c:\
   - SET PATH=C:\Program Files\MySql\MySQL Server 5.7\bin\;%PATH%
-  - cinst php --version 7.0.9  --allow-empty-checksums
-  - SET PATH=C:\tools\php\;%PATH%
-  - copy C:\tools\php\php.ini-production C:\tools\php\php.ini
-  - echo date.timezone="Asia/Tokyo" >> C:\tools\php\php.ini
-  - echo extension_dir=ext >> C:\tools\php\php.ini
-  - echo extension=php_openssl.dll >> C:\tools\php\php.ini
-  - echo extension=php_gd2.dll >> C:\tools\php\php.ini
-  - echo extension=php_mbstring.dll >> C:\tools\php\php.ini
-  - echo extension=php_pgsql.dll >> C:\tools\php\php.ini
-  - echo extension=php_pdo_mysql.dll >> C:\tools\php\php.ini
-  - echo extension=php_pdo_pgsql.dll >> C:\tools\php\php.ini
-  - echo extension=php_curl.dll >> C:\tools\php\php.ini
-  - echo extension=php_fileinfo.dll >> C:\tools\php\php.ini
-  - echo output_buffering = Off >> C:\tools\php\php.ini
-  - echo default_charset = UTF-8 >> C:\tools\php\php.ini
-  - echo mbstring.language = Japanese >> C:\tools\php\php.ini
-  - echo mbstring.encoding_translation = On >> C:\tools\php\php.ini
-  - echo mbstring.http_input = UTF-8 >> C:\tools\php\php.ini
-  - echo mbstring.http_output = pass >> C:\tools\php\php.ini
-  - echo mbstring.internal_encoding = UTF-8 >> C:\tools\php\php.ini
-  - echo memory_limit = 512M >> C:\tools\php\php.ini
+  - cinst php --version 7.1.23  --allow-empty-checksums
+  - SET PATH=C:\tools\php71\;%PATH%
+  - copy C:\tools\php71\php.ini-production C:\tools\php71\php.ini
+  - echo date.timezone="Asia/Tokyo" >> C:\tools\php71\php.ini
+  - echo extension_dir=ext >> C:\tools\php71\php.ini
+  - echo extension=php_openssl.dll >> C:\tools\php71\php.ini
+  - echo extension=php_gd2.dll >> C:\tools\php71\php.ini
+  - echo extension=php_mbstring.dll >> C:\tools\php71\php.ini
+  - echo extension=php_pgsql.dll >> C:\tools\php71\php.ini
+  - echo extension=php_pdo_mysql.dll >> C:\tools\php71\php.ini
+  - echo extension=php_pdo_pgsql.dll >> C:\tools\php71\php.ini
+  - echo extension=php_curl.dll >> C:\tools\php71\php.ini
+  - echo extension=php_fileinfo.dll >> C:\tools\php71\php.ini
+  - echo output_buffering = Off >> C:\tools\php71\php.ini
+  - echo default_charset = UTF-8 >> C:\tools\php71\php.ini
+  - echo mbstring.language = Japanese >> C:\tools\php71\php.ini
+  - echo mbstring.encoding_translation = On >> C:\tools\php71\php.ini
+  - echo mbstring.http_input = UTF-8 >> C:\tools\php71\php.ini
+  - echo mbstring.http_output = pass >> C:\tools\php71\php.ini
+  - echo mbstring.internal_encoding = UTF-8 >> C:\tools\php71\php.ini
+  - echo memory_limit = 512M >> C:\tools\php71\php.ini
   - php -r "readfile('http://getcomposer.org/installer');" | php
   - php composer.phar install --dev --no-interaction -o
 


### PR DESCRIPTION
- EC-CUBE 3.0.16 を追加
- PHP7.1 を追加
- AppVeyor が落ちるため修正
  - PHP7.1.23 に変更
  - 本体に合わせて OpenSSL.Light を追加