### PR TITLE
テストケースの修正

### DIFF
--- a/Tests/Service/CouponServiceTest.php
+++ b/Tests/Service/CouponServiceTest.php
@@ -311,7 +311,7 @@ class CouponServiceTest extends EccubeTestCase
         }
 
         $this->actual = $discount;
-        $this->expected = (int) round($total * $discountRate / 100);
+        $this->expected = (int) round(round($total) * $discountRate / 100);
         $this->verify();
     }
 


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
ランダムに一定の確率で（約５％）消費税計算が１円の誤差が発生し、テストが失敗していたため、テストケースの修正を行った。

## 方針(Policy)
テストコードにはクーポン割引の合計額から、小数点以下を四捨五入する処理が抜けていたため、追加している。