### PR TITLE
クーポンを利用せずに購入しようとすると購入完了画面でエラーになるのを修正

### DIFF
--- a/Service/PurchaseFlow/Processor/CouponProcessor.php
+++ b/Service/PurchaseFlow/Processor/CouponProcessor.php
@@ -184,6 +184,9 @@ class CouponProcessor extends ItemHolderValidator implements ItemHolderPreproces
         }
 
         $CouponOrder = $this->couponOrderRepository->getCouponOrder($itemHolder->getPreOrderId());
+        if (!$CouponOrder) {
+            return;
+        }
         $CouponOrder->setOrderDate(new \DateTime());
         $this->entityManager->flush($CouponOrder);
 


### PR DESCRIPTION
#91 への修正。

一応、テストとして、
プラウグインを有効にした状態で、修正の前後で
tests/Eccube/Tests/Web/ShoppingControllerTest.php
をテストし、エラーが解消しているのを確認。