### PR TITLE
全商品対象の場合, 値引き対象の商品全てに値引きが適用されないのを修正

### DIFF
--- a/Service/CouponService.php
+++ b/Service/CouponService.php
@@ -172,7 +172,7 @@ class CouponService
                 // 一致する商品IDがあればtrueを返す
                 /** @var OrderItem $detail */
                 foreach ($Order->getItems()->getProductClasses() as $detail) {
-                    $couponProducts = $this->getCouponProducts($detail);
+                    $couponProducts = $this->getCouponProducts($detail) + $couponProducts;
                 }
             }
         }

--- a/Tests/Service/CouponServiceTest.php
+++ b/Tests/Service/CouponServiceTest.php
@@ -175,6 +175,31 @@ class CouponServiceTest extends EccubeTestCase
     }
 
     /**
+     * testExistsCouponProductAll
+     */
+    public function testExistsCouponProductAll()
+    {
+        $orderItemVolume = 5;
+        /** @var Generator $Generator */
+        $Generator = $this->container->get(Generator::class);
+        /** @var Coupon $Coupon */
+        $Coupon = $this->getCoupon(Coupon::ALL);
+
+        $Customer = $this->createCustomer();
+
+        $details = $Coupon->getCouponDetails();
+        $Product = $Generator->createProduct(null, $orderItemVolume);
+        $Order = $Generator->createOrder($Customer, $Product->getProductClasses()->toArray());
+        $products = $this->couponService->existsCouponProduct($Coupon, $Order);
+
+        $this->actual = count($products);
+
+        $this->expected = $orderItemVolume;
+
+        $this->verify();
+    }
+
+    /**
      * testSaveCouponOrder.
      */
     public function testSaveCouponOrder()


### PR DESCRIPTION
対象商品を全商品にして、複数商品を購入した場合、全ての商品に値引きが適用されなかったのを修正
 