### PR TITLE
複数配送時、注文内容が変更になった場合クーポンを初期化するよう修正

### DIFF
--- a/Resource/locale/messages.ja.yml
+++ b/Resource/locale/messages.ja.yml
@@ -70,6 +70,7 @@ plugin_coupon.front.shopping.minus: 合計金額を超えるため、このク�
 plugin_coupon.front.shopping.use.minus: クーポン適用後の合計金額がマイナスになったため、クーポンの利用をキャンセルしました。
 plugin_coupon.front.shopping.member: このクーポンは会員のみ利用できるクーポンです。
 plugin_coupon.front.shopping.lowerlimit: このクーポンを利用するためには、対象商品をlowerLimit円以上購入してください。
+plugin_coupon.front.shopping.changeorder: 注文内容が変更になりました。クーポンをご利用の場合は再度設定をお願いいたします。
 plugin_coupon.front.shopping.notfound: このクーポンコードは利用できません。
 plugin_coupon.front.shopping.header: クーポン
 plugin_coupon.front.shopping.message.use_code: クーポンコード %code% を利用しています。

--- a/Service/CouponService.php
+++ b/Service/CouponService.php
@@ -344,6 +344,7 @@ class CouponService
         if ($CouponOrder) {
             $OrderItems = $this->orderItemRepository->findBy(['processor_name' => CouponProcessor::class]);
             foreach ($OrderItems as $OrderItem) {
+                $Order->removeOrderItem($OrderItem);
                 $this->entityManager->remove($OrderItem);
                 $this->entityManager->flush($OrderItem);
             }

--- a/Service/CouponService.php
+++ b/Service/CouponService.php
@@ -265,12 +265,11 @@ class CouponService
     /**
      * 合計、値引きを再計算する.
      *
+     * 税率が 0 以下の場合は、TaxRule から取得し直して再計算する
+     *
      * @param Coupon $Coupon
-     * @param array  $couponProducts
-     *
+     * @param array  $couponProducts ProductClass::id をキーにした単価, 数量, 税率の連想配列
      * @return float|int|string
-     *
-     * @throws \Doctrine\ORM\NoResultException
      */
     public function recalcOrder(Coupon $Coupon, $couponProducts)
     {

--- a/Service/CouponService.php
+++ b/Service/CouponService.php
@@ -172,7 +172,7 @@ class CouponService
                 // 一致する商品IDがあればtrueを返す
                 /** @var OrderItem $detail */
                 foreach ($Order->getItems()->getProductClasses() as $detail) {
-                    $couponProducts = $this->getCouponProducts($detail) + $couponProducts;
+                    $couponProducts = $this->getCouponProducts($detail, $couponProducts);
                 }
             }
         }
@@ -407,7 +407,7 @@ class CouponService
         /* @var $detail OrderItem */
         foreach ($Order->getProductOrderItems() as $detail) {
             if (in_array($detail->getProduct()->getId(), $targetProductIds)) {
-                $couponProducts = $this->getCouponProducts($detail) + $couponProducts;
+                $couponProducts = $this->getCouponProducts($detail, $couponProducts);
             }
         }
 
@@ -436,7 +436,7 @@ class CouponService
         foreach ($Order->getProductOrderItems() as $orderDetail) {
             foreach ($orderDetail->getProduct()->getProductCategories() as $productCategory) {
                 if ($this->existsDepthCategory($targetCategoryIds, $productCategory->getCategory())) {
-                    $couponProducts = $this->getCouponProducts($orderDetail) + $couponProducts ;
+                    $couponProducts = $this->getCouponProducts($orderDetail, $couponProducts);
                 }
             }
         }
@@ -480,17 +480,22 @@ class CouponService
     }
 
     /**
-     * @param $orderItem
+     * @param OrderItem $orderItem
+     * @param array $couponProducts
      *
      * @return mixed
      */
-    private function getCouponProducts(OrderItem $orderItem)
+    private function getCouponProducts(OrderItem $orderItem, array $couponProducts = [])
     {
-        $couponProducts[$orderItem->getProductClass()->getId()]['price'] = $orderItem->getPrice();
-        $couponProducts[$orderItem->getProductClass()->getId()]['quantity'] = $orderItem->getQuantity();
-        $couponProducts[$orderItem->getProductClass()->getId()]['tax_rate'] = $orderItem->getTaxRate();
-        // $couponProducts[$orderItem->getProductClass()->getId()]['tax_rule'] = $orderItem->getTaxRule();
-
+        if (array_key_exists($orderItem->getProductClass()->getId(), $couponProducts)) {
+            $couponProducts[$orderItem->getProductClass()->getId()]['quantity'] += $orderItem->getQuantity();
+        } else {
+            $couponProducts[$orderItem->getProductClass()->getId()] = [
+                'price' => $orderItem->getPrice(),
+                'quantity' => $orderItem->getQuantity(),
+                'tax_rate' => $orderItem->getTaxRate()
+            ];
+        }
         return $couponProducts;
     }
 }

--- a/Service/PurchaseFlow/Processor/CouponProcessor.php
+++ b/Service/PurchaseFlow/Processor/CouponProcessor.php
@@ -138,7 +138,7 @@ class CouponProcessor extends ItemHolderValidator implements ItemHolderPreproces
         $Coupon = $this->couponRepository->findActiveCoupon($CouponOrder->getCouponCd());
         if (!$Coupon) {
             $this->clearCoupon($itemHolder);
-            $this->throwInvalidItemException('クーポンが取得できませんでした', null, true);
+            $this->throwInvalidItemException(trans('plugin_coupon.front.shopping.notfound'), null, true);
         }
 
         /** @var Customer $Customer */
@@ -156,7 +156,7 @@ class CouponProcessor extends ItemHolderValidator implements ItemHolderPreproces
         $discount = $this->couponService->recalcOrder($Coupon, $couponProducts);
         if ($discount != $CouponOrder->getDiscount()) {
             $this->clearCoupon($itemHolder);
-            $this->throwInvalidItemException('注文内容が変更になりました。クーポンをご利用の場合は再度設定をお願いいたします。', null, true);
+            $this->throwInvalidItemException(trans('plugin_coupon.front.shopping.changeorder'), null, true);
         }
 
         $lowerLimit = $Coupon->getCouponLowerLimit();

--- a/Tests/Service/CouponServiceTest.php
+++ b/Tests/Service/CouponServiceTest.php
@@ -201,6 +201,7 @@ class CouponServiceTest extends EccubeTestCase
 
     /**
      * testExistsCouponProductWithMultiple
+     * https://github.com/EC-CUBE/coupon-plugin/issues/102 のテストケース
      */
     public function testExistsCouponProductWithMultiple()
     {


### PR DESCRIPTION
- #105 のあとにマージお願いします
- #101, #103 の修正
- 元の CouponOrder の値引額と、再計算した値引額が異なる場合は、クーポンと注文の値引明細を初期化する
- 複数配送時、 CouponProcessor で税率の取得ができない場合に TaxRule から取得し直す

## TODO
- [x] 注文情報を修正しなくても値引き額に差異が出る場合があるのを修正する
- [x] テスト書く
- [x] メッセージのベタ書きを修正する