### PR TITLE
AuthenticationCredentialsNotFoundException が発生するのを修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: php
 
 sudo: required


### PR DESCRIPTION
kernel.request event で FRONT_SHOPPING_CONFIRM_INITIALIZE が dispatch された場合は, TokenStorage が有効になっていないため, セッションから自前で復元するように修正

YamatoPayment との組み合わせで発生する。

https://xoops.ec-cube.net/modules/newbb/viewtopic.php?topic_id=22565&forum=16&post_id=94124#forumpost94124

