### PR TITLE
四捨五入固定で計算している箇所を修正

### DIFF
--- a/Service/CouponService.php
+++ b/Service/CouponService.php
@@ -523,6 +523,8 @@ class CouponService
             $couponProducts[$orderItem->getProductClass()->getId()] = [
                 'price' => $orderItem->getPrice(),
                 'quantity' => $orderItem->getQuantity(),
+                // tax_rate, rounding_type_idは複数配送の個数変更時に取得できない. recalcOrderで取得し直している
+                // https://github.com/EC-CUBE/coupon-plugin/pull/106/commits/d47f60745b283023cd7a990c609e6399701ddce1
                 'tax_rate' => $orderItem->getTaxRate(),
                 'rounding_type_id' => $orderItem->getRoundingType() ? $orderItem->getRoundingType()->getId() : null,
             ];

--- a/Service/CouponService.php
+++ b/Service/CouponService.php
@@ -292,8 +292,9 @@ class CouponService
                         $ProductClass = $this->productClassRepository->find($productClassId);
                         $TaxRule = $this->taxRuleRepository->getByRule($ProductClass->getProduct(), $ProductClass);
                         $value['tax_rate'] = $TaxRule->getTaxRate();
+                        $value['rounding_type_id'] = $TaxRule->getRoundingType()->getId();
                     }
-                    $total += ($value['price'] + $this->taxRuleService->calcTax($value['price'], $value['tax_rate'], RoundingType::ROUND)) * $value['quantity'];
+                    $total += ($value['price'] + $this->taxRuleService->calcTax($value['price'], $value['tax_rate'], $value['rounding_type_id'])) * $value['quantity'];
                 }
                 /** @var TaxRule $DefaultTaxRule */
                 $DefaultTaxRule = $this->taxRuleRepository->getByRule();
@@ -323,7 +324,7 @@ class CouponService
         $subTotal = 0;
         // price inc tax
         foreach ($productCoupon as $key => $value) {
-            $subTotal += ($value['price'] + $this->taxRuleService->calcTax($value['price'], $value['tax_rate'], RoundingType::ROUND)) * $value['quantity'];
+            $subTotal += ($value['price'] + $this->taxRuleService->calcTax($value['price'], $value['tax_rate'], $value['rounding_type_id'])) * $value['quantity'];
         }
 
         if ($subTotal < $lowerLimitMoney && $subTotal != 0) {
@@ -522,7 +523,8 @@ class CouponService
             $couponProducts[$orderItem->getProductClass()->getId()] = [
                 'price' => $orderItem->getPrice(),
                 'quantity' => $orderItem->getQuantity(),
-                'tax_rate' => $orderItem->getTaxRate()
+                'tax_rate' => $orderItem->getTaxRate(),
+                'rounding_type_id' => $orderItem->getRoundingType()->getId(),
             ];
         }
 

--- a/Service/CouponService.php
+++ b/Service/CouponService.php
@@ -287,7 +287,7 @@ class CouponService
                 // include tax
                 foreach ($couponProducts as $productClassId => $value) {
                     // 税率が取得できない場合は TaxRule から取得し直す
-                    if ($value['tax_rate'] < 1) {
+                    if ($value['tax_rate'] < 1 || $value['rounding_type_id'] === null) {
                         /** @var ProductClass $ProductClass */
                         $ProductClass = $this->productClassRepository->find($productClassId);
                         $TaxRule = $this->taxRuleRepository->getByRule($ProductClass->getProduct(), $ProductClass);
@@ -524,7 +524,7 @@ class CouponService
                 'price' => $orderItem->getPrice(),
                 'quantity' => $orderItem->getQuantity(),
                 'tax_rate' => $orderItem->getTaxRate(),
-                'rounding_type_id' => $orderItem->getRoundingType()->getId(),
+                'rounding_type_id' => $orderItem->getRoundingType() ? $orderItem->getRoundingType()->getId() : null,
             ];
         }
 

--- a/Tests/Service/CouponServiceTest.php
+++ b/Tests/Service/CouponServiceTest.php
@@ -465,6 +465,7 @@ class CouponServiceTest extends EccubeTestCase
     ) {
         $TaxRule = $this->taxRuleRepository->find(TaxRule::DEFAULT_TAX_RULE_ID);
         $TaxRule->setTaxRate($taxRate);
+        $TaxRule->setRoundingType($this->entityManager->find(RoundingType::class, $roundingTypeId));
         $this->entityManager->flush($TaxRule);
 
         /** @var Coupon $Coupon */


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#120 の修正

## 方針(Policy)

四捨五入固定ではなく、税率の設定から丸め規則を取得して税込価格を算出するように修正

## 実装に関する補足
https://github.com/EC-CUBE/coupon-plugin/pull/122/files#diff-216fd804c4ed1d51175c94119b745d26R529

複数配送の個数変更時、丸め規則が取得できないため、recalcOrderメソッドで再取得するように対応しています。

## テスト（Test)
- ユニットテストを追加

