### PR TITLE
複数カテゴリ時に、値引き額が多重に計算される不具合の修正

### DIFF
--- a/Service/CouponService.php
+++ b/Service/CouponService.php
@@ -466,6 +466,7 @@ class CouponService
             foreach ($orderDetail->getProduct()->getProductCategories() as $productCategory) {
                 if ($this->existsDepthCategory($targetCategoryIds, $productCategory->getCategory())) {
                     $couponProducts = $this->getCouponProducts($orderDetail, $couponProducts);
+                    break;
                 }
             }
         }

--- a/Tests/Service/CouponServiceTest.php
+++ b/Tests/Service/CouponServiceTest.php
@@ -449,6 +449,46 @@ class CouponServiceTest extends EccubeTestCase
         $this->verify();
     }
 
+    /**
+     * @see https://github.com/EC-CUBE/coupon-plugin/issues/121
+     */
+    public function testContainsCategory()
+    {
+        /** @var Coupon $Coupon */
+        $Coupon = $this->getTestData(Coupon::CATEGORY, Coupon::DISCOUNT_PRICE);
+        $Coupon->setVisible(true);
+
+        $Product = $this->createProduct(null, 0);
+        $ProductClass = $Product->getProductClasses()->first();
+
+        $ProductCategories = $Product->getProductCategories();
+        $Customer = $this->createCustomer();
+        $Order = $this->createOrderWithProductClasses($Customer, [$ProductClass]);
+
+        $quantity = $Order->getProductOrderItems()[0]->getQuantity();
+
+        foreach ($ProductCategories as $ProductCategory) {
+            $CouponDetail = new CouponDetail();
+            $CouponDetail->setCoupon($Coupon);
+            $CouponDetail->setCouponType($Coupon->getCouponType());
+            $CouponDetail->setUpdateDate($Coupon->getUpdateDate());
+            $CouponDetail->setCreateDate($Coupon->getCreateDate());
+            $CouponDetail->setVisible(true);
+            $CouponDetail->setCategory($ProductCategory->getCategory());
+            $Coupon->addCouponDetail($CouponDetail);
+            $this->entityManager->persist($CouponDetail);
+            $this->entityManager->flush($CouponDetail);
+        }
+
+        $this->entityManager->flush();
+
+        $method = new \ReflectionMethod(CouponService::class, 'containsCategory');
+        $method->setAccessible(true);
+        $result = $method->invoke($this->couponService, $Coupon, $Order);
+
+        self::assertEquals($quantity, $result[$ProductClass->getId()]['quantity']);
+    }
+
     public function testSetOrderCompleteMailMessage()
     {
         $Order = new Order();


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
#121 の修正

## 方針(Policy)

明細*明細のカテゴリの分だけループしていたため、カテゴリと一致した時点で次の明細を処理するように対応しています。

## テスト（Test)
- ユニットテストを追加

