### PR TITLE
rollbackでクーポンの利用回数が戻るように修正

### DIFF
--- a/Service/PurchaseFlow/Processor/CouponProcessor.php
+++ b/Service/PurchaseFlow/Processor/CouponProcessor.php
@@ -221,6 +221,18 @@ class CouponProcessor extends ItemHolderValidator implements ItemHolderPreproces
             return;
         }
 
+        $CouponOrder = $this->couponOrderRepository->getCouponOrder($itemHolder->getPreOrderId());
+        if (!$CouponOrder) {
+            return;
+        }
+
+        // クーポンの利用回数を戻す
+        $Coupon = $this->couponRepository->findActiveCoupon($CouponOrder->getCouponCd());
+        if ($Coupon) {
+            $Coupon->setCouponUseTime($Coupon->getCouponUseTime() + 1);
+            $this->entityManager->flush($Coupon);
+        }
+
         $this->couponService->removeCouponOrder($itemHolder);
     }
 

--- a/Tests/Service/PurchaseFlow/Processor/CouponProcessorTest.php
+++ b/Tests/Service/PurchaseFlow/Processor/CouponProcessorTest.php
@@ -535,6 +535,7 @@ class CouponProcessorTest extends EccubeTestCase
     public function testRollback()
     {
         $Coupon = $this->getCoupon();
+        $useTime = $Coupon->getCouponUseTime();
         $this->container->get('security.token_storage')->setToken(
             new UsernamePasswordToken(
                 $this->Customer, null, 'customer', $this->Customer->getRoles()
@@ -554,6 +555,10 @@ class CouponProcessorTest extends EccubeTestCase
         });
 
         $this->assertTrue($OrderItems->isEmpty(), 'クーポンの明細が削除されている');
+
+        $this->expected = $useTime + 1;
+        $this->actual = $Coupon->getCouponUseTime();
+        $this->verify();
     }
 
     public function testRollbackWithNotSupport()


### PR DESCRIPTION
rollbackでクーポンの利用回数が戻るように修正しました。

rollbackでクーポンの利用回数が戻らなかった。
リンク決済などで「リンク決済画面 -> EC-CUBEへ戻る」を繰り返すとクーポンの利用回数が減っていく状態となっていた。

サンプルペイメントプラグインのリンク式決済で動作確認しました。

開発コミュニティとslackで報告をいただきました。
https://xoops.ec-cube.net/modules/newbb/viewtopic.php?forum=16&post_id=102513&topic_id=25477
https://ec-cube.slack.com/archives/C03P2Q8QL/p1615511216014500
