### PR TITLE
PHP 8.1環境でクーポン対象商品を検索できない不具合の修正

### DIFF
--- a/Controller/Admin/CouponSearchModelController.php
+++ b/Controller/Admin/CouponSearchModelController.php
@@ -61,7 +61,7 @@ class CouponSearchModelController extends AbstractController
      * @Route("/%eccube_admin_route%/plugin/coupon/search/product/page/{page_no}", requirements={"page_no" = "\d+"}, name="plugin_coupon_search_product_page")
      * @Template("@Coupon42/admin/search_product.twig")
      */
-    public function searchProduct(Request $request, $page_no = null, PaginatorInterface $paginator)
+    public function searchProduct(Request $request, PaginatorInterface $paginator, $page_no = null)
     {
         if (!$request->isXmlHttpRequest()) {
             return null;

--- a/Tests/Web/Admin/CouponSearchModelControllerTest.php
+++ b/Tests/Web/Admin/CouponSearchModelControllerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+namespace Plugin\Coupon42\Tests\Web\Admin;
+
+use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
+use Eccube\Tests\Web\Admin\Order\AbstractEditControllerTestCase;
+use PHPUnit\Framework\TestCase;
+use Plugin\Coupon42\Tests\Fixtures\CreateCouponTrait;
+
+/**
+ * Class CouponSearchModelControllerTest.
+ */
+class CouponSearchModelControllerTest extends AbstractEditControllerTestCase
+{
+    use CreateCouponTrait;
+
+    /**
+     * setUp.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function testSearchProduct()
+    {
+        $Product = $this->createProduct();
+        $crawler = $this->client->request('POST', $this->generateUrl('plugin_coupon_search_product'),
+            [
+                'id' => $Product->getName(),
+                'category_id' => '',
+                'exist_product_id' => ''
+            ],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ]);
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $this->assertStringContainsString($Product->getName(), $crawler->html());
+    }
+}


### PR DESCRIPTION
PHP8.1環境でクーポン登録・編集画面で
対象商品を検索すると

`Controller "Plugin\Coupon42\Controller\Admin\CouponSearchModelController::searchProduct()" requires that you provide a value for the "$page_no" argument. Either the argument is nullable and no null value has been provided, no default value has been provided or because there is a non optional argument after this one.`

上記のエラーが発生されます。その原因で商品を検索できないところになります。

その原因はsearchProduct関数の引数順番の問題でした。

なので、任意引数を左から最後の引数に移動しました。

テストケースを作成しました。


