### PR TITLE
クーポン削除モーダルのメッセージ表示をEC-CUBE本体に合わせた

### DIFF
--- a/Resource/locale/messages.ja.yml
+++ b/Resource/locale/messages.ja.yml
@@ -14,7 +14,8 @@ plugin_coupon.admin.index.col09: 有効期間
 plugin_coupon.admin.index.col10: 編集
 plugin_coupon.admin.index.col11: 状態
 plugin_coupon.admin.index.col12: 削除
-plugin_coupon.admin.index.delete.confirm: このクーポンを削除しても宜しいですか？
+plugin_coupon.admin.index.delete__confirm_title: クーポンを削除します
+plugin_coupon.admin.index.delete__confirm_message: クーポンを削除してよろしいですか？
 plugin_coupon.admin.coupon_member.yes: 会員のみ
 plugin_coupon.admin.coupon_member.no: なし
 plugin_coupon.admin.coupon_type.product: 商品

--- a/Resource/template/admin/index.twig
+++ b/Resource/template/admin/index.twig
@@ -96,12 +96,12 @@
                                                 <div class="modal-content">
                                                     <div class="modal-header">
                                                         <h5 class="modal-title font-weight-bold">
-                                                            {{ 'plugin_coupon.admin.index.delete.confirm'|trans }}</h5>
+                                                            {{ 'plugin_coupon.admin.index.delete__confirm_title'|trans }}</h5>
                                                         <button class="btn-close" type="button" data-bs-dismiss="modal" aria-label="Close"></button>
                                                     </div>
-                                                    <div class="modal-body text-end">
-                                                        <p class="text-end">
-                                                            {{ 'plugin_coupon.admin.index.delete.confirm'|trans }}</p>
+                                                    <div class="modal-body text-start">
+                                                        <p class="text-start">
+                                                            {{ 'plugin_coupon.admin.index.delete__confirm_message'|trans }}</p>
                                                     </div>
                                                     <div class="modal-footer">
                                                         <button class="btn btn-ec-sub" type="button"

--- a/Resource/template/admin/index.twig
+++ b/Resource/template/admin/index.twig
@@ -95,7 +95,7 @@
                                             <div class="modal-dialog" role="document">
                                                 <div class="modal-content">
                                                     <div class="modal-header">
-                                                        <h5 class="modal-title font-weight-bold">
+                                                        <h5 class="modal-title fw-bold">
                                                             {{ 'plugin_coupon.admin.index.delete__confirm_title'|trans }}</h5>
                                                         <button class="btn-close" type="button" data-bs-dismiss="modal" aria-label="Close"></button>
                                                     </div>


### PR DESCRIPTION
## 概要
クーポン削除時に表示されるモーダルのメッセージ内容とレイアウトが、EC-CUBE本体と統一できていなかったのを修正しました。

## 修正前
<img width="518" alt="スクリーンショット 2022-08-27 23 50 17" src="https://user-images.githubusercontent.com/16891862/187035897-84890e09-49a0-476c-bda9-9bf5706f2143.png">

## 修正後
<img width="518" alt="image" src="https://user-images.githubusercontent.com/16891862/187036103-069bef78-9575-4ad4-b0f8-2513567aa877.png">

## 参考：商品削除
<img width="517" alt="image" src="https://user-images.githubusercontent.com/16891862/187035955-5e020da9-7a40-4533-8724-e2dbe57ef89b.png">


