### PR TITLE
モーダルにボタンを本体に統一するように修正

### DIFF
--- a/Resource/template/admin/search_category.twig
+++ b/Resource/template/admin/search_category.twig
@@ -49,9 +49,9 @@
                     </td>
                     <td>
                     </td>
-                    <td class="text-end">
-                        <button onclick="fnAddCategoryDetail($(this).parent().parent(), {{ id }},  '{{ name|escape('js') }}')" type="button" class="btn btn-secondary btn-sm">
-                            {{ 'common.ok'|trans }}
+                    <td class="align-middle text-end">
+                        <button onclick="fnAddCategoryDetail($(this).parent().parent(), {{ id }},  '{{ name|escape('js') }}')" type="button" class="btn btn-ec-actionIcon">
+                            <i class="fa fa-plus fa-lg fw-bold text-secondary"></i>
                         </button>
                     </td>
                 </tr>

--- a/Resource/template/admin/search_product.twig
+++ b/Resource/template/admin/search_product.twig
@@ -87,9 +87,9 @@
                             {% endif %}
                         </span>
                     </td>
-                    <td class="text-end">
-                        <button onclick="fnAddProductDetail($(this).parent().parent(), {{ Product.id }},  '{{ Product.name|escape('js') }}')" type="button" class="btn btn-secondary btn-sm">
-                            {{ 'common.ok'|trans }}
+                    <td class="align-middle text-end">
+                        <button onclick="fnAddProductDetail($(this).parent().parent(), {{ Product.id }},  '{{ Product.name|escape('js') }}')" type="button" class="btn btn-ec-actionIcon">
+                            <i class="fa fa-plus fa-lg fw-bold text-secondary"></i>
                         </button>
                     </td>
                 </tr>


### PR DESCRIPTION
おすすめ商品プラグインの[#56](https://github.com/EC-CUBE/Recommend-plugin/pull/56)と同様に
商品/カテゴリーの決定ボタンをEC-CUBE本体に統一するようにしました