### PR TITLE
削除ボタンの表示をアイコンに変更

### DIFF
--- a/Resource/template/admin/regist.twig
+++ b/Resource/template/admin/regist.twig
@@ -408,7 +408,9 @@
                                                         </div>
                                                     </div>
                                                     <div class="col-1 icon_edit">
-                                                        <button class="btn btn-default btn-sm delete-item">{{ 'common.delete'|trans }}</button>
+                                                        <a class="btn btn-ec-actionIcon mr-3 delete-item" data-bs-toggle="modal" data-bs-toggle="tooltip" data-bs-target="#confirmModal" data-bs-placement="top" title="{{ 'admin.common.delete'|trans }}">
+                                                            <i class="fa fa-close fa-lg text-secondary"></i>
+                                                        </a>
                                                     </div>
                                                 </div><!-- /.item_box -->
                                             {% endif %}
@@ -468,7 +470,9 @@
                                                     </div>
 
                                                     <div class="col-1 icon_edit">
-                                                        <button class="btn btn-default btn-sm delete-item">{{ 'common.delete'|trans }}</button>
+                                                        <a class="btn btn-ec-actionIcon mr-3 delete-item" data-bs-toggle="modal" data-bs-toggle="tooltip" data-bs-target="#confirmModal" data-bs-placement="top" title="{{ 'admin.common.delete'|trans }}">
+                                                            <i class="fa fa-close fa-lg text-secondary"></i>
+                                                        </a>
                                                     </div>
                                                 </div><!-- /.item_box -->
                                             {% endif %}

--- a/Resource/template/admin/regist_category_list_prototype.twig
+++ b/Resource/template/admin/regist_category_list_prototype.twig
@@ -13,7 +13,9 @@
         </div>
 
         <div class="col-1 icon_edit">
-            <button class="btn btn-secondary btn-sm delete-item">削除</button>
+            <a class="btn btn-ec-actionIcon mr-3 delete-item" data-bs-toggle="modal" data-bs-toggle="tooltip" data-bs-target="#confirmModal" data-bs-placement="top" title="{{ 'admin.common.delete'|trans }}">
+                <i class="fa fa-close fa-lg text-secondary"></i>
+            </a>
         </div>
     </div><!-- /.item_box -->
 {% endfilter %}

--- a/Resource/template/admin/regist_product_list_prototype.twig
+++ b/Resource/template/admin/regist_product_list_prototype.twig
@@ -14,7 +14,9 @@
             </div>
         </div>
         <div class="col-1 icon_edit">
-            <button class="btn btn-secondary btn-sm delete-item">削除</button>
+            <a class="btn btn-ec-actionIcon mr-3 delete-item" data-bs-toggle="modal" data-bs-toggle="tooltip" data-bs-target="#confirmModal" data-bs-placement="top" title="{{ 'admin.common.delete'|trans }}">
+                <i class="fa fa-close fa-lg text-secondary"></i>
+            </a>
         </div>
     </div><!-- /.item_box -->
 {% endfilter %}


### PR DESCRIPTION
削除ボタンが、マウスオーバーしても反応がなく認識しずらいため
他と同じように×アイコンに修正しました

![image](https://user-images.githubusercontent.com/8424850/187200658-c500d970-2be4-4af3-9935-dfd5563e6868.png)
