### PR TITLE
クーポンを削除する処理を修正

### DIFF
--- a/Controller/CouponShoppingController.php
+++ b/Controller/CouponShoppingController.php
@@ -123,14 +123,11 @@ class CouponShoppingController extends AbstractController
             // クーポンコード入力項目追加
             // ----------------------------------
             if ($formCouponCancel == 0) {
-                if (!is_null($formCouponCd)) {
-                    // 画面上のクーポンコードが入力されておらず、既にクーポンコードが登録されていればクーポンを無効にする
-                    $this->couponService->removeCouponOrder($Order);
-                }
-
+                // クーポンを利用しない
+                $this->couponService->removeCouponOrder($Order);
                 return $this->redirectToRoute('shopping');
             } else {
-                // クーポンコードが入力されている
+                // クーポンを利用する
                 $discount = 0;
                 $error = false;
                 // クーポン情報を取得

--- a/Service/CouponService.php
+++ b/Service/CouponService.php
@@ -367,7 +367,6 @@ class CouponService
      */
     public function removeCouponOrder(ItemHolderInterface $Order)
     {
-        // クーポンが未入力でクーポン情報が存在すればクーポン情報を削除
         /** @var CouponOrder $CouponOrder */
         $CouponOrder = $this->couponOrderRepository->getCouponOrder($Order->getPreOrderId());
         if ($CouponOrder) {


### PR DESCRIPTION
[#171](https://github.com/EC-CUBE/coupon-plugin/issues/171)のissueに対応しました。

[以前](https://github.com/EC-CUBE/coupon-plugin/blob/6949d95121f657b1433bc9efb721cc5f6e489d3b/Resource/template/default/shopping_coupon.twig)はラジオボタンはなく、クーポンコードの入力テキストのみだったようです。
その際には、「画面上のクーポンコードが入力されておらず、既にクーポンコードが登録されていればクーポンを無効にする」という処理は正しかったですが
ラジオボタンができてからは、ラジオボタンの選択肢のみに依存し、削除をする処理でよいように思います。