### PR TITLE
[Coupon42] 制限を超える文字を入力するとシステム エラーが発生するくなる 不具合の修正 

### DIFF
--- a/Form/Type/CouponType.php
+++ b/Form/Type/CouponType.php
@@ -76,6 +76,7 @@ class CouponType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $max = 9999999999;
         $currency = $this->container->getParameter('currency');
         $builder
             ->add('coupon_cd', TextType::class, [
@@ -85,6 +86,9 @@ class CouponType extends AbstractType
                 'constraints' => [
                     new Assert\NotBlank(),
                     new Assert\Regex(['pattern' => '/^[a-zA-Z0-9]+$/i']),
+                    new Assert\Length([
+                        'max' => 20,
+                    ]),
                 ],
             ])
             ->add('coupon_name', TextType::class, [
@@ -93,6 +97,9 @@ class CouponType extends AbstractType
                 'trim' => true,
                 'constraints' => [
                     new Assert\NotBlank(),
+                    new Assert\Length([
+                        'max' => 50,
+                    ]),
                 ],
             ])
             ->add('coupon_type', ChoiceType::class, [
@@ -142,6 +149,7 @@ class CouponType extends AbstractType
                 'constraints' => [
                     new Assert\Range([
                         'min' => 0,
+                        'max'=> $max,
                     ]),
                 ],
             ])
@@ -152,6 +160,7 @@ class CouponType extends AbstractType
                 'constraints' => [
                     new Assert\Range([
                         'min' => 0,
+                        'max' => $max,
                     ]),
                 ],
             ])
@@ -173,6 +182,10 @@ class CouponType extends AbstractType
                 'widget' => 'single_text',
                 'constraints' => [
                     new Assert\NotBlank(),
+                    new Assert\Range([
+                        'min'=> '0003-01-01',
+                        'minMessage' => 'form_error.out_of_range',
+                    ]),
                 ],
             ])
             // 有効期間(TO)
@@ -183,6 +196,10 @@ class CouponType extends AbstractType
                 'widget' => 'single_text',
                 'constraints' => [
                     new Assert\NotBlank(),
+                    new Assert\Range([
+                        'min'=> '0003-01-01',
+                        'minMessage' => 'form_error.out_of_range',
+                    ]),
                 ],
             ])
             ->add('coupon_release', IntegerType::class, [


### PR DESCRIPTION
<!-- 以下を参考にコメントを作成してください。 -->

## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->
以下のissue https://github.com/EC-CUBE/coupon-plugin/issues/186 の対応です
[Coupon42] 制限を超える文字を入力するとシステム エラーが発生する

## 方針(Policy)
<!-- このPullRequestを作るにあたって考慮したものや除外した内容
  - 例）Symfony のXXにならって作成、3系で同様の仕様があったため など -->

## 実装に関する補足(Appendix)
<!-- コードだけではわかりづらい点など、実装するにあたってレビューアに追加で伝えておきたいこと -->

## テスト（Test)
<!-- テストを行っている範囲など、レビューアが安心できるような情報 -->
この問題を修正し、次のような機能テストを行いました。
![image](https://user-images.githubusercontent.com/104967957/192431254-9ad90b93-f139-4ab2-8e1a-97f9bf75de33.png)

![image](https://user-images.githubusercontent.com/104967957/192431379-3109d9f7-7c59-444a-83d5-1e61664febd0.png)


## 相談（Discussion）
<!-- 相談したいことや意見を求めたいこと -->
