### PR TITLE
fix: EC-CUBE 4.4 で削除される OrderItem::setTaxRuleId() の呼び出しを除去

### DIFF
--- a/Service/PurchaseFlow/Processor/CouponProcessor.php
+++ b/Service/PurchaseFlow/Processor/CouponProcessor.php
@@ -283,19 +283,19 @@ class CouponProcessor extends ItemHolderValidator implements ItemHolderPreproces
         $taxType = TaxType::NON_TAXABLE; // 不課税
         $tax = 0;
         $taxRate = 0;
-        $taxRuleId = null;
         $roundingType = null;
         $DiscountType = $this->entityManager->find(OrderItemType::class, OrderItemType::DISCOUNT);
         $TaxInclude = $this->entityManager->find(TaxDisplayType::class, $taxDisplayType);
         $Taxation = $this->entityManager->find(TaxType::class, $taxType);
 
         $OrderItem = new OrderItem();
+        // 課税規則 ID は設定しない。OrderItem::setTaxRuleId() は EC-CUBE 4.4 で削除されており
+        // (税率設定は受注作成時に決定するため)、書き込んだ値の読み手も本体・プラグインに存在しない
         $OrderItem->setProductName($CouponOrder->getCouponName())
             ->setPrice((string) ($CouponOrder->getDiscount() * -1))
             ->setQuantity('1')
             ->setTax((string) $tax)
             ->setTaxRate((string) $taxRate)
-            ->setTaxRuleId($taxRuleId)
             ->setRoundingType($roundingType)
             ->setOrderItemType($DiscountType)
             ->setTaxDisplayType($TaxInclude)

--- a/Tests/Repository/CouponCouponOrderRepositoryTest.php
+++ b/Tests/Repository/CouponCouponOrderRepositoryTest.php
@@ -151,7 +151,6 @@ class CouponCouponOrderRepositoryTest extends EccubeTestCase
             ->setProductName('discount')
             ->setPrice((string) (0 - $discount))
             ->setQuantity('1')
-            ->setTaxRuleId($TaxRule->getId())
             ->setTaxRate($TaxRule->getTaxRate());
         $this->entityManager->persist($orderItem);
         $this->entityManager->flush();

--- a/Tests/Service/CouponServiceTest.php
+++ b/Tests/Service/CouponServiceTest.php
@@ -122,7 +122,6 @@ class CouponServiceTest extends EccubeTestCase
             ->setOrderItemType($OrderItemTypeProduct)
             ->setPrice($ProductClass->getPrice02())
             ->setQuantity('1')
-            ->setTaxRuleId($TaxRule->getId())
             ->setTaxRate($TaxRule->getTaxRate());
         $this->entityManager->persist($orderItem);
         $orderItem->setOrder($Order);
@@ -317,7 +316,6 @@ class CouponServiceTest extends EccubeTestCase
             ->setOrderItemType($OrderItemTypeProduct)
             ->setPrice($ProductClass->getPrice02())
             ->setQuantity('1')
-            ->setTaxRuleId($TaxRule->getId())
             ->setTaxRate($TaxRule->getTaxRate());
         $this->entityManager->persist($orderItem);
         $orderItem->setOrder($Order);
@@ -371,7 +369,6 @@ class CouponServiceTest extends EccubeTestCase
             ->setOrderItemType($OrderItemTypeProduct)
             ->setPrice($ProductClass->getPrice02())
             ->setQuantity('1')
-            ->setTaxRuleId($TaxRule->getId())
             ->setTaxRate($TaxRule->getTaxRate());
         $this->entityManager->persist($orderItem);
         $orderItem->setOrder($Order);
@@ -433,7 +430,6 @@ class CouponServiceTest extends EccubeTestCase
             ->setPrice($ProductClass->getPrice02())
             ->setQuantity('1')
             // OrderItem に税率は設定しない
-            ->setTaxRuleId(null)
             ->setTaxRate('0');
         $this->entityManager->persist($orderItem);
         $orderItem->setOrder($Order);


### PR DESCRIPTION
## 概要

close #198

EC-CUBE 本体 4.4 で非推奨 public API を撤去する [EC-CUBE/ec-cube#6937](https://github.com/EC-CUBE/ec-cube/pull/6937) により `Eccube\Entity\OrderItem::setTaxRuleId()` / `getTaxRuleId()` が削除されるため、本プラグインからの呼び出しを除去します。

**#197（EC-CUBE 4.4 対応）へのスタック PR** です。base は `feature/eccube-4.4-symfony7`。#197 がマージされたら base は自動的に `4.4` に切り替わります。

## 変更内容

| ファイル | 内容 |
|---|---|
| `Service/PurchaseFlow/Processor/CouponProcessor.php` | クーポン値引き明細生成時の `setTaxRuleId($taxRuleId)` と、未使用になる `$taxRuleId` 変数を削除。意図が失われないようコメントを残す |
| `Tests/Service/CouponServiceTest.php` | テストフィクスチャの `setTaxRuleId()` 4 箇所を削除 |
| `Tests/Repository/CouponCouponOrderRepositoryTest.php` | 同 1 箇所を削除 |

## 削除だけで済む理由

- `tax_rule_id` カラムは `OrderItem` の private プロパティとして残るため、**既存データは失われません**
- 本プラグインは `setTaxRuleId()` による書き込みのみで、`getTaxRuleId()` での読み出しはありません
- 本体 4.4 の `src/` `app/` にも `getTaxRuleId()` の呼び出しはなく、書き込んだ値の読み手が存在しません
- 受注/配送 CSV の `tax_rule`（税率ルール(ID)）項目は `CsvExportService::getData()` が `getTaxRule()` を探す実装のため、**現状でも空欄出力**であり、この変更で出力は変わりません

したがって代替処理は不要で、呼び出しの削除のみで対応しています。

- クーポン値引き明細は従来どおり「税込・税率 0%・不課税」で生成されます（`setTaxRate('0')` / `TaxType::NON_TAXABLE` は変更なし）
- `CouponServiceTest` の「OrderItem に税率は設定しない」ケースは、`tax_rule_id` の既定値が `null` のため `setTaxRuleId(null)` の削除は挙動に影響しません

## テスト

ローカルの docker-compose 4.4 環境（`8.2-apache-4.4` / SQLite / PHP 8.2.31）で確認済み：

- **PHPUnit 11.5.55**: 127 tests / 196 assertions パス（**Failures/Errors 0**、Skipped 1）※ #197 のレビュー指摘対応（ae08221）へリベース後に再実行
  - Skipped 1 件は #197 で説明済みの `OrderControllerTest::testOrderEditWithCouponCancel`（本体 4.4 テストハーネスの悲観ロック制約）で、本 PR とは無関係です
- **php-cs-fixer**: 差分ゼロ（30 files）
- **rector**: 変更ゼロ
- **phpstan level 6**: エラーゼロ（baseline なし）

なお現行の本体 4.4 では `OrderItem::setTaxRuleId()` はまだ削除されていない（非推奨のまま）ため、本 PR の適用前後どちらでもテストは成立します。本体 PR がマージされた時点で、本 PR 未適用だと fatal error になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

