### PR TITLE
fix: Bootstrap 5 に存在しない mr-2 / mr-3 を me-2 / me-3 に修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,8 @@ jobs:
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - uses: actions/cache@v1
+          echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.playwright-mcp/console-2026-07-03T06-08-39-000Z.log
+++ b/.playwright-mcp/console-2026-07-03T06-08-39-000Z.log
@@ -1,0 +1,9 @@
+[     701ms] [ERROR] Failed to load resource: the server responded with a status of 404 (Not Found) @ http://localhost:8080/html/upload/save_image/cube-1.png:0
+[    1097ms] [WARNING] Failed to decode downloaded font: http://localhost:8080/html/bundle/f7f1e7911cd4fe275e29.woff @ http://localhost:8080/:0
+[    1098ms] [WARNING] OTS parsing error: invalid sfntVersion: 1702391919 @ http://localhost:8080/:0
+[    1117ms] [WARNING] Failed to decode downloaded font: http://localhost:8080/html/bundle/ad0c1b9dc2d8ec4e2fa0.ttf @ http://localhost:8080/:0
+[    1117ms] [WARNING] OTS parsing error: invalid sfntVersion: 1702391919 @ http://localhost:8080/:0
+[    1136ms] [WARNING] Failed to decode downloaded font: http://localhost:8080/html/bundle/f7f1e7911cd4fe275e29.woff @ http://localhost:8080/:0
+[    1136ms] [WARNING] OTS parsing error: invalid sfntVersion: 1702391919 @ http://localhost:8080/:0
+[    1136ms] [WARNING] Failed to decode downloaded font: http://localhost:8080/html/bundle/ad0c1b9dc2d8ec4e2fa0.ttf @ http://localhost:8080/:0
+[    1136ms] [WARNING] OTS parsing error: invalid sfntVersion: 1702391919 @ http://localhost:8080/:0

--- a/.playwright-mcp/console-2026-07-03T06-11-05-543Z.log
+++ b/.playwright-mcp/console-2026-07-03T06-11-05-543Z.log
@@ -1,0 +1,2 @@
+[   10132ms] [VERBOSE] [DOM] Input elements should have autocomplete attributes (suggested: "current-password"): (More info: https://goo.gl/9p2vKq) %o @ http://localhost:8080/shopping/login:0
+[   65007ms] [ERROR] Failed to load resource: the server responded with a status of 404 (Not Found) @ http://localhost:8080/_wdt/1bea7e?XDEBUG_IGNORE=1:0

--- a/.playwright-mcp/console-2026-07-03T07-21-45-178Z.log
+++ b/.playwright-mcp/console-2026-07-03T07-21-45-178Z.log
@@ -1,0 +1,1 @@
+[    3949ms] [ERROR] Failed to load resource: the server responded with a status of 500 (Internal Server Error) @ http://localhost:8080/products/detail/2:0

--- a/.playwright-mcp/console-2026-07-03T07-23-46-777Z.log
+++ b/.playwright-mcp/console-2026-07-03T07-23-46-777Z.log
@@ -1,0 +1,1 @@
+[     487ms] [VERBOSE] [DOM] Input elements should have autocomplete attributes (suggested: "current-password"): (More info: https://goo.gl/9p2vKq) %o @ http://localhost:8080/shopping/login:0

--- a/.playwright-mcp/console-2026-07-03T07-23-52-103Z.log
+++ b/.playwright-mcp/console-2026-07-03T07-23-52-103Z.log
@@ -1,0 +1,1 @@
+[   23170ms] [ERROR] Failed to load resource: the server responded with a status of 404 (Not Found) @ http://localhost:8080/_wdt/7a937b?XDEBUG_IGNORE=1:0

--- a/.playwright-mcp/console-2026-08-03T05-24-54-665Z.log
+++ b/.playwright-mcp/console-2026-08-03T05-24-54-665Z.log
@@ -1,0 +1,1 @@
+[    2030ms] [ERROR] Failed to load resource: the server responded with a status of 500 (Internal Server Error) @ http://localhost:8080/admin:0

--- a/.playwright-mcp/console-2026-08-03T05-25-15-939Z.log
+++ b/.playwright-mcp/console-2026-08-03T05-25-15-939Z.log
@@ -1,0 +1,1 @@
+[   13896ms] [VERBOSE] [DOM] Input elements should have autocomplete attributes (suggested: "current-password"): (More info: https://goo.gl/9p2vKq) %o @ http://localhost:8080/admin/login:0

--- a/.playwright-mcp/console-2026-08-03T05-26-22-269Z.log
+++ b/.playwright-mcp/console-2026-08-03T05-26-22-269Z.log
@@ -1,0 +1,4 @@
+[     128ms] [ERROR] Failed to load resource: the server responded with a status of 404 (Not Found) @ http://localhost:8080/html/template/admin/assets/css/bootstrap-datetimepicker.min.css:0
+[     129ms] [ERROR] Failed to load resource: the server responded with a status of 404 (Not Found) @ http://localhost:8080/html/template/admin/assets/js/vendor/moment-ja.js:0
+[     146ms] [ERROR] Failed to load resource: the server responded with a status of 404 (Not Found) @ http://localhost:8080/html/template/admin/assets/js/vendor/bootstrap-datetimepicker.min.js:0
+[   18342ms] [WARNING] The specified value "2026/01/01" does not conform to the required format, "yyyy-MM-dd". @ :7346

--- a/.playwright-mcp/console-2026-08-03T05-27-30-163Z.log
+++ b/.playwright-mcp/console-2026-08-03T05-27-30-163Z.log
@@ -1,0 +1,1 @@
+[     203ms] [ERROR] Failed to load resource: the server responded with a status of 404 (Not Found) @ http://localhost:8080/html/upload/save_image/cube-1.png:0

--- a/.playwright-mcp/console-2026-08-03T05-28-11-671Z.log
+++ b/.playwright-mcp/console-2026-08-03T05-28-11-671Z.log
@@ -1,0 +1,1 @@
+[     249ms] [VERBOSE] [DOM] Input elements should have autocomplete attributes (suggested: "current-password"): (More info: https://goo.gl/9p2vKq) %o @ http://localhost:8080/shopping/login:0

--- a/.playwright-mcp/console-2026-08-03T05-28-33-323Z.log
+++ b/.playwright-mcp/console-2026-08-03T05-28-33-323Z.log
@@ -1,0 +1,1 @@
+[   29583ms] [ERROR] Failed to load resource: the server responded with a status of 404 (Not Found) @ http://localhost:8080/_wdt/8f4730?XDEBUG_IGNORE=1:0

--- a/.playwright-mcp/console-2026-08-03T05-29-19-528Z.log
+++ b/.playwright-mcp/console-2026-08-03T05-29-19-528Z.log
@@ -1,0 +1,1 @@
+[     117ms] [ERROR] Failed to load resource: the server responded with a status of 500 (Internal Server Error) @ http://localhost:8080/plugin/coupon/shopping/shopping_coupon:0

--- a/.playwright-mcp/console-2026-08-03T05-30-36-166Z.log
+++ b/.playwright-mcp/console-2026-08-03T05-30-36-166Z.log
@@ -1,0 +1,1 @@
+[   14433ms] [ERROR] Failed to load resource: the server responded with a status of 404 (Not Found) @ http://localhost:8080/_wdt/9ad88a?XDEBUG_IGNORE=1:0

--- a/.playwright-mcp/console-2026-08-03T05-32-24-002Z.log
+++ b/.playwright-mcp/console-2026-08-03T05-32-24-002Z.log
@@ -1,0 +1,2 @@
+[     309ms] [ERROR] Failed to load resource: the server responded with a status of 404 (Not Found) @ http://localhost:8080/_wdt/b0bee8?XDEBUG_IGNORE=1:0
+[   15068ms] [ERROR] Failed to load resource: the server responded with a status of 500 (Internal Server Error) @ http://localhost:8080/shopping/shipping_multiple:0

--- a/.playwright-mcp/page-2026-07-03T06-08-40-319Z.yml
+++ b/.playwright-mcp/page-2026-07-03T06-08-40-319Z.yml
@@ -1,0 +1,245 @@
+- generic [active] [ref=e1]:
+  - generic [ref=e3]:
+    - img [ref=e5]
+    - text: デバッグモードが有効になっています。
+  - generic [ref=e6]:
+    - banner [ref=e7]:
+      - generic [ref=e8]:
+        - generic [ref=e9]:
+          - generic [ref=e11]:
+            - generic:
+              - combobox [ref=e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=e16]:
+                - searchbox "キーワードを入力" [ref=e17]
+                - button [ref=e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=e20]:
+          - generic [ref=e22]:
+            - link " 新規会員登録" [ref=e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=e25]: 
+              - generic [ref=e26]: 新規会員登録
+            - link " お気に入り" [ref=e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=e29]: 
+              - generic [ref=e30]: お気に入り
+            - link " ログイン" [ref=e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=e33]: 
+              - generic [ref=e34]: ログイン
+          - generic [ref=e37] [cursor=pointer]:
+            - generic [ref=e38]:
+              - text: 
+              - generic [ref=e39]: "0"
+            - generic [ref=e41]: ￥0
+      - heading "EC-CUBE SHOP" [level=1] [ref=e46]:
+        - link "EC-CUBE SHOP" [ref=e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=e50]:
+        - listitem [ref=e51]:
+          - link "新入荷" [ref=e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=e53]:
+          - link "ジェラート" [ref=e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=e57]:
+          - link "アイスサンド" [ref=e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=e61]:
+      - generic [ref=e63]:
+        - generic [ref=e65]:
+          - img [ref=e68]
+          - tabpanel [ref=e69]:
+            - img [ref=e71]
+          - tabpanel [ref=e72]:
+            - img [ref=e74]
+          - tabpanel [ref=e75]:
+            - img [ref=e77]
+          - img [ref=e80]
+          - img [ref=e83]
+          - img [ref=e86]
+        - tablist [ref=e87]:
+          - tab "1 of 3" [selected] [ref=e88] [cursor=pointer]: "1"
+          - tab "2 of 3" [ref=e89] [cursor=pointer]: "2"
+          - tab "3 of 3" [ref=e90] [cursor=pointer]: "3"
+      - generic [ref=e91]:
+        - generic [ref=e95]:
+          - paragraph [ref=e96]: CUBE GELATO ICE
+          - paragraph [ref=e97]: 彩のジェラート"CUBE"をご堪能ください。
+          - paragraph [ref=e98]:
+            - text: ジェラートとはイタリアン・アイスクリームのことで、一般的なアイスクリームに比べて、乳脂肪分が低くいのが特徴です。
+            - text: 当店では厳選した旬の果物のおいしさをそのままジェラートに仕上げました。風味が濃厚でありながら、甘さ控えめでヘルシーなキューブジェラートをご堪能ください。
+            - text: さらにジェラートの製法を活かした、アイスキャンディ・アイスサンドも販売しております。
+          - link "一覧を見る" [ref=e99] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=4
+        - generic [ref=e101]:
+          - generic [ref=e102]:
+            - text: TOPICS
+            - text: 特集
+          - generic [ref=e104]:
+            - generic [ref=e105]:
+              - link [ref=e106] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=1
+                - img [ref=e107]
+              - paragraph [ref=e108]: 濃厚なのにアイスよりヘルシー!! ジェラート特集
+            - generic [ref=e109]:
+              - link [ref=e110] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=5
+                - img [ref=e111]
+              - paragraph [ref=e112]: サクサク食感が魅力!! コーンアイス特集
+        - generic [ref=e115]:
+          - generic [ref=e117]:
+            - generic [ref=e118]: NEW ITEM
+            - generic [ref=e120]: 新着商品
+            - link "more" [ref=e121] [cursor=pointer]:
+              - /url: http://localhost:8080/products/list
+          - link "彩のジェラート\"CUBE\" ￥1,200(税込)" [ref=e123] [cursor=pointer]:
+            - /url: http://localhost:8080/products/detail/1
+            - img [ref=e124]
+            - paragraph [ref=e125]: 彩のジェラート"CUBE"
+            - paragraph [ref=e126]: ￥1,200(税込)
+          - link "チェリーアイスサンド ￥800(税込)" [ref=e128] [cursor=pointer]:
+            - /url: http://localhost:8080/products/detail/2
+            - img [ref=e129]
+            - paragraph [ref=e130]: チェリーアイスサンド
+            - paragraph [ref=e131]: ￥800(税込)
+          - link "彩のジェラート\"CUBE\" NEO ￥600(税込)" [ref=e133] [cursor=pointer]:
+            - /url: http://localhost:8080/products/detail/1
+            - img [ref=e134]
+            - paragraph [ref=e135]: 彩のジェラート"CUBE" NEO
+            - paragraph [ref=e136]: ￥600(税込)
+        - generic [ref=e138]:
+          - generic [ref=e139]:
+            - text: CATEGORY
+            - text: カテゴリ
+          - generic [ref=e141]:
+            - link [ref=e143] [cursor=pointer]:
+              - /url: http://localhost:8080/products/list?category_id=2
+              - img [ref=e144]
+            - link [ref=e146] [cursor=pointer]:
+              - /url: http://localhost:8080/products/list?category_id=1
+              - img [ref=e147]
+            - link [ref=e149] [cursor=pointer]:
+              - /url: http://localhost:8080/products/list?category_id=5
+              - img [ref=e150]
+        - generic [ref=e152]:
+          - generic [ref=e153]:
+            - text: NEWS
+            - text: 新着情報
+          - generic [ref=e157] [cursor=pointer]:
+            - generic [ref=e158]: 2018/09/01
+            - generic [ref=e159]:
+              - generic [ref=e160]: サイトオープンいたしました!
+              - generic [ref=e163]: 
+    - contentinfo [ref=e164]:
+      - generic [ref=e166]:
+        - list [ref=e167]:
+          - listitem [ref=e168]:
+            - link "当サイトについて" [ref=e169] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=e170]:
+            - link "プライバシーポリシー" [ref=e171] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=e172]:
+            - link "特定商取引法に基づく表記" [ref=e173] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=e174]:
+            - link "お問い合わせ" [ref=e175] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=e176]:
+          - link "EC-CUBE SHOP" [ref=e178] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=e179]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=e180]:
+    - generic [ref=e183]:
+      - link "200 @ homepage" [ref=e185] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/e3142c?panel=request
+        - generic [ref=e186]:
+          - generic [ref=e187]: "200"
+          - generic [ref=e188]: "@"
+          - generic [ref=e189]: homepage
+      - link "250 ms" [ref=e191] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/e3142c?panel=time
+        - generic [ref=e192]:
+          - generic [ref=e193]: "250"
+          - generic [ref=e194]: ms
+      - link "10.0 MiB" [ref=e196] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/e3142c?panel=time
+        - generic [ref=e197]:
+          - generic [ref=e198]: "10.0"
+          - generic [ref=e199]: MiB
+      - link "Cache 1" [ref=e201] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/e3142c?panel=form
+        - generic [ref=e202]:
+          - img "Cache" [ref=e203]
+          - generic [ref=e209]: "1"
+      - link "Logger 484" [ref=e211] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/e3142c?panel=logger
+        - generic [ref=e212]:
+          - img "Logger" [ref=e213]
+          - generic [ref=e217]: "484"
+      - link "Cache 18 in 0.36 ms" [ref=e219] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/e3142c?panel=cache
+        - generic [ref=e220]:
+          - img "Cache" [ref=e221]
+          - generic [ref=e226]: "18"
+          - generic [ref=e227]: in 0.36 ms
+      - link "39" [ref=e229] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/e3142c?panel=translation
+        - generic [ref=e230]:
+          - img [ref=e231]
+          - generic [ref=e236]: "39"
+      - link "Security n/a" [ref=e238] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/e3142c?panel=security
+        - generic [ref=e239]:
+          - img "Security" [ref=e240]
+          - generic [ref=e244]: n/a
+      - link "Twig 58 ms" [ref=e246] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/e3142c?panel=twig
+        - generic [ref=e247]:
+          - img "Twig" [ref=e248]
+          - generic [ref=e252]: "58"
+          - generic [ref=e253]: ms
+      - link "12 in 3.16 ms" [ref=e255] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/e3142c?panel=db
+        - generic [ref=e256]:
+          - img [ref=e257]
+          - generic [ref=e262]: "12"
+          - generic [ref=e263]: in 3.16 ms
+      - link "22" [ref=e265] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/e3142c?panel=doctrine_migrations
+        - generic [ref=e266]:
+          - img [ref=e267]
+          - generic [ref=e270]: "22"
+      - link "Symfony 7.4.13" [ref=e272] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/e3142c?panel=config
+        - generic [ref=e273]:
+          - img "Symfony" [ref=e275]
+          - generic [ref=e277]: 7.4.13
+      - generic [ref=e279]:
+        - img "eccube_logo_basic" [ref=e280]
+        - generic [ref=e285]: 4.3.1-p1
+      - button "Toggle Symfony Toolbar" [expanded] [ref=e286] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=e287]:
+          - img [ref=e288]

--- a/.playwright-mcp/page-2026-07-03T06-10-41-082Z.yml
+++ b/.playwright-mcp/page-2026-07-03T06-10-41-082Z.yml
@@ -1,0 +1,194 @@
+- generic [active] [ref=f1e1]:
+  - generic [ref=f1e3]:
+    - img [ref=f1e5]
+    - text: デバッグモードが有効になっています。
+  - generic [ref=f1e6]:
+    - banner [ref=f1e7]:
+      - generic [ref=f1e8]:
+        - generic [ref=f1e9]:
+          - generic [ref=f1e11]:
+            - generic:
+              - combobox [ref=f1e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f1e16]:
+                - searchbox "キーワードを入力" [ref=f1e17]
+                - button [ref=f1e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f1e20]:
+          - generic [ref=f1e22]:
+            - link " 新規会員登録" [ref=f1e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f1e25]: 
+              - generic [ref=f1e26]: 新規会員登録
+            - link " お気に入り" [ref=f1e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f1e29]: 
+              - generic [ref=f1e30]: お気に入り
+            - link " ログイン" [ref=f1e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f1e33]: 
+              - generic [ref=f1e34]: ログイン
+          - generic [ref=f1e37] [cursor=pointer]:
+            - generic [ref=f1e38]:
+              - text: 
+              - generic [ref=f1e39]: "0"
+            - generic [ref=f1e41]: ￥0
+      - heading "EC-CUBE SHOP" [level=1] [ref=f1e46]:
+        - link "EC-CUBE SHOP" [ref=f1e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f1e50]:
+        - listitem [ref=f1e51]:
+          - link "新入荷" [ref=f1e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f1e53]:
+          - link "ジェラート" [ref=f1e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f1e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f1e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f1e57]:
+          - link "アイスサンド" [ref=f1e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f1e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f1e61]:
+      - generic [ref=f1e63]:
+        - generic [ref=f1e68]:
+          - img "チェリーアイスサンド" [ref=f1e75]
+          - img [ref=f1e85]
+        - generic [ref=f1e97]:
+          - heading "チェリーアイスサンド" [level=2] [ref=f1e99]
+          - list [ref=f1e100]
+          - text: 通常価格：￥3,300 税込
+          - generic [ref=f1e102]:
+            - generic [ref=f1e103]: ￥3,080
+            - text: 税込
+          - generic [ref=f1e104]: 商品コード： sand-01
+          - generic [ref=f1e105]:
+            - generic [ref=f1e106]: 関連カテゴリ
+            - list [ref=f1e107]:
+              - listitem [ref=f1e108]:
+                - link "新入荷" [ref=f1e109] [cursor=pointer]:
+                  - /url: http://localhost:8080/products/list?category_id=2
+              - listitem [ref=f1e110]:
+                - link "アイスサンド" [ref=f1e111] [cursor=pointer]:
+                  - /url: http://localhost:8080/products/list?category_id=5
+                - text: ">"
+                - link "フルーツ" [ref=f1e112] [cursor=pointer]:
+                  - /url: http://localhost:8080/products/list?category_id=6
+          - generic [ref=f1e113]:
+            - generic [ref=f1e115]:
+              - text: 数量
+              - spinbutton [ref=f1e116]: "1"
+            - button "カートに入れる" [ref=f1e118] [cursor=pointer]
+          - button "お気に入りに追加" [ref=f1e121] [cursor=pointer]
+          - generic [ref=f1e122]:
+            - text: チェリーアイスサンドは北海道産のチェリーのアイスをサクサクのクッキーでサンドしたスイーツです。
+            - text: 立方体なので大量に持ち運ぶときも便利です。
+            - text: いまだけ、頑丈な箱つきです。
+    - contentinfo [ref=f1e123]:
+      - generic [ref=f1e125]:
+        - list [ref=f1e126]:
+          - listitem [ref=f1e127]:
+            - link "当サイトについて" [ref=f1e128] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f1e129]:
+            - link "プライバシーポリシー" [ref=f1e130] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f1e131]:
+            - link "特定商取引法に基づく表記" [ref=f1e132] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f1e133]:
+            - link "お問い合わせ" [ref=f1e134] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f1e135]:
+          - link "EC-CUBE SHOP" [ref=f1e137] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f1e138]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f1e139]:
+    - generic [ref=f1e142]:
+      - link "200 @ product_detail" [ref=f1e144] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=request
+        - generic [ref=f1e145]:
+          - generic [ref=f1e146]: "200"
+          - generic [ref=f1e147]: "@"
+          - generic [ref=f1e148]: product_detail
+      - link "182 ms" [ref=f1e150] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=time
+        - generic [ref=f1e151]:
+          - generic [ref=f1e152]: "182"
+          - generic [ref=f1e153]: ms
+      - link "12.0 MiB" [ref=f1e155] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=time
+        - generic [ref=f1e156]:
+          - generic [ref=f1e157]: "12.0"
+          - generic [ref=f1e158]: MiB
+      - link "Cache 1" [ref=f1e160] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=form
+        - generic [ref=f1e161]:
+          - img "Cache" [ref=f1e162]
+          - generic [ref=f1e168]: "1"
+      - link "Logger 487" [ref=f1e170] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=logger
+        - generic [ref=f1e171]:
+          - img "Logger" [ref=f1e172]
+          - generic [ref=f1e176]: "487"
+      - link "Cache 24 in 0.46 ms" [ref=f1e178] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=cache
+        - generic [ref=f1e179]:
+          - img "Cache" [ref=f1e180]
+          - generic [ref=f1e185]: "24"
+          - generic [ref=f1e186]: in 0.46 ms
+      - link "30" [ref=f1e188] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=translation
+        - generic [ref=f1e189]:
+          - img [ref=f1e190]
+          - generic [ref=f1e195]: "30"
+      - link "Security n/a" [ref=f1e197] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=security
+        - generic [ref=f1e198]:
+          - img "Security" [ref=f1e199]
+          - generic [ref=f1e203]: n/a
+      - link "Twig 42 ms" [ref=f1e205] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=twig
+        - generic [ref=f1e206]:
+          - img "Twig" [ref=f1e207]
+          - generic [ref=f1e211]: "42"
+          - generic [ref=f1e212]: ms
+      - link "14 in 5.89 ms" [ref=f1e214] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=db
+        - generic [ref=f1e215]:
+          - img [ref=f1e216]
+          - generic [ref=f1e221]: "14"
+          - generic [ref=f1e222]: in 5.89 ms
+      - link "22" [ref=f1e224] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=doctrine_migrations
+        - generic [ref=f1e225]:
+          - img [ref=f1e226]
+          - generic [ref=f1e229]: "22"
+      - link "Symfony 7.4.13" [ref=f1e231] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=config
+        - generic [ref=f1e232]:
+          - img "Symfony" [ref=f1e234]
+          - generic [ref=f1e236]: 7.4.13
+      - generic [ref=f1e238]:
+        - img "eccube_logo_basic" [ref=f1e239]
+        - generic [ref=f1e244]: 4.3.1-p1
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f1e245] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f1e246]:
+          - img [ref=f1e247]

--- a/.playwright-mcp/page-2026-07-03T06-10-59-326Z.yml
+++ b/.playwright-mcp/page-2026-07-03T06-10-59-326Z.yml
@@ -1,0 +1,203 @@
+- generic [active] [ref=f1e1]:
+  - generic [ref=f1e3]:
+    - img [ref=f1e5]
+    - text: デバッグモードが有効になっています。
+  - generic [ref=f1e6]:
+    - banner [ref=f1e7]:
+      - generic [ref=f1e8]:
+        - generic [ref=f1e9]:
+          - generic [ref=f1e11]:
+            - generic:
+              - combobox [ref=f1e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f1e16]:
+                - searchbox "キーワードを入力" [ref=f1e17]
+                - button [ref=f1e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f1e20]:
+          - generic [ref=f1e22]:
+            - link " 新規会員登録" [ref=f1e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f1e25]: 
+              - generic [ref=f1e26]: 新規会員登録
+            - link " お気に入り" [ref=f1e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f1e29]: 
+              - generic [ref=f1e30]: お気に入り
+            - link " ログイン" [ref=f1e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f1e33]: 
+              - generic [ref=f1e34]: ログイン
+          - generic [ref=f1e252] [cursor=pointer]:
+            - generic [ref=f1e253]:
+              - text: 
+              - generic [ref=f1e254]: "1"
+            - generic [ref=f1e256]: ￥3,080
+      - heading "EC-CUBE SHOP" [level=1] [ref=f1e46]:
+        - link "EC-CUBE SHOP" [ref=f1e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f1e50]:
+        - listitem [ref=f1e51]:
+          - link "新入荷" [ref=f1e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f1e53]:
+          - link "ジェラート" [ref=f1e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f1e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f1e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f1e57]:
+          - link "アイスサンド" [ref=f1e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f1e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f1e61]:
+      - generic [ref=f1e63]:
+        - generic [ref=f1e68]:
+          - img "チェリーアイスサンド" [ref=f1e75]
+          - img [ref=f1e85]
+        - generic [ref=f1e97]:
+          - heading "チェリーアイスサンド" [level=2] [ref=f1e99]
+          - list [ref=f1e100]
+          - text: 通常価格：￥3,300 税込
+          - generic [ref=f1e102]:
+            - generic [ref=f1e103]: ￥3,080
+            - text: 税込
+          - generic [ref=f1e104]: 商品コード： sand-01
+          - generic [ref=f1e105]:
+            - generic [ref=f1e106]: 関連カテゴリ
+            - list [ref=f1e107]:
+              - listitem [ref=f1e108]:
+                - link "新入荷" [ref=f1e109] [cursor=pointer]:
+                  - /url: http://localhost:8080/products/list?category_id=2
+              - listitem [ref=f1e110]:
+                - link "アイスサンド" [ref=f1e111] [cursor=pointer]:
+                  - /url: http://localhost:8080/products/list?category_id=5
+                - text: ">"
+                - link "フルーツ" [ref=f1e112] [cursor=pointer]:
+                  - /url: http://localhost:8080/products/list?category_id=6
+          - generic [ref=f1e113]:
+            - generic [ref=f1e115]:
+              - text: 数量
+              - spinbutton [ref=f1e116]: "1"
+            - button "カートに入れる" [ref=f1e118] [cursor=pointer]
+          - generic [ref=f1e259]:
+            - generic [ref=f1e262]: カートに追加しました。
+            - generic [ref=f1e264]:
+              - generic [ref=f1e265] [cursor=pointer]: お買い物を続ける
+              - link "カートへ進む" [ref=f1e266] [cursor=pointer]:
+                - /url: http://localhost:8080/cart
+          - button "お気に入りに追加" [ref=f1e121] [cursor=pointer]
+          - generic [ref=f1e122]:
+            - text: チェリーアイスサンドは北海道産のチェリーのアイスをサクサクのクッキーでサンドしたスイーツです。
+            - text: 立方体なので大量に持ち運ぶときも便利です。
+            - text: いまだけ、頑丈な箱つきです。
+    - contentinfo [ref=f1e123]:
+      - generic [ref=f1e125]:
+        - list [ref=f1e126]:
+          - listitem [ref=f1e127]:
+            - link "当サイトについて" [ref=f1e128] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f1e129]:
+            - link "プライバシーポリシー" [ref=f1e130] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f1e131]:
+            - link "特定商取引法に基づく表記" [ref=f1e132] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f1e133]:
+            - link "お問い合わせ" [ref=f1e134] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f1e135]:
+          - link "EC-CUBE SHOP" [ref=f1e137] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f1e138]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f1e139]:
+    - generic [ref=f1e142]:
+      - link "200 @ product_detail" [ref=f1e144] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=request
+        - generic [ref=f1e145]:
+          - generic [ref=f1e146]: "200"
+          - generic [ref=f1e147]: "@"
+          - generic [ref=f1e148]: product_detail
+      - link "182 ms" [ref=f1e150] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=time
+        - generic [ref=f1e151]:
+          - generic [ref=f1e152]: "182"
+          - generic [ref=f1e153]: ms
+      - link "12.0 MiB" [ref=f1e155] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=time
+        - generic [ref=f1e156]:
+          - generic [ref=f1e157]: "12.0"
+          - generic [ref=f1e158]: MiB
+      - generic [ref=f1e268] [cursor=pointer]:
+        - img [ref=f1e269]
+        - generic [ref=f1e273]: "2"
+      - link "Cache 1" [ref=f1e160] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=form
+        - generic [ref=f1e161]:
+          - img "Cache" [ref=f1e162]
+          - generic [ref=f1e168]: "1"
+      - link "Logger 487" [ref=f1e170] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=logger
+        - generic [ref=f1e171]:
+          - img "Logger" [ref=f1e172]
+          - generic [ref=f1e176]: "487"
+      - link "Cache 24 in 0.46 ms" [ref=f1e178] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=cache
+        - generic [ref=f1e179]:
+          - img "Cache" [ref=f1e180]
+          - generic [ref=f1e185]: "24"
+          - generic [ref=f1e186]: in 0.46 ms
+      - link "30" [ref=f1e188] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=translation
+        - generic [ref=f1e189]:
+          - img [ref=f1e190]
+          - generic [ref=f1e195]: "30"
+      - link "Security n/a" [ref=f1e197] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=security
+        - generic [ref=f1e198]:
+          - img "Security" [ref=f1e199]
+          - generic [ref=f1e203]: n/a
+      - link "Twig 42 ms" [ref=f1e205] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=twig
+        - generic [ref=f1e206]:
+          - img "Twig" [ref=f1e207]
+          - generic [ref=f1e211]: "42"
+          - generic [ref=f1e212]: ms
+      - link "14 in 5.89 ms" [ref=f1e214] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=db
+        - generic [ref=f1e215]:
+          - img [ref=f1e216]
+          - generic [ref=f1e221]: "14"
+          - generic [ref=f1e222]: in 5.89 ms
+      - link "22" [ref=f1e224] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=doctrine_migrations
+        - generic [ref=f1e225]:
+          - img [ref=f1e226]
+          - generic [ref=f1e229]: "22"
+      - link "Symfony 7.4.13" [ref=f1e231] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/17760a?panel=config
+        - generic [ref=f1e232]:
+          - img "Symfony" [ref=f1e234]
+          - generic [ref=f1e236]: 7.4.13
+      - generic [ref=f1e238]:
+        - img "eccube_logo_basic" [ref=f1e239]
+        - generic [ref=f1e244]: 4.3.1-p1
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f1e245] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f1e246]:
+          - img [ref=f1e247]

--- a/.playwright-mcp/page-2026-07-03T06-11-05-809Z.yml
+++ b/.playwright-mcp/page-2026-07-03T06-11-05-809Z.yml
@@ -1,0 +1,217 @@
+- generic [active] [ref=f2e1]:
+  - generic [ref=f2e3]:
+    - img [ref=f2e5]
+    - text: デバッグモードが有効になっています。
+  - generic [ref=f2e6]:
+    - banner [ref=f2e7]:
+      - generic [ref=f2e8]:
+        - generic [ref=f2e9]:
+          - generic [ref=f2e11]:
+            - generic:
+              - combobox [ref=f2e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f2e16]:
+                - searchbox "キーワードを入力" [ref=f2e17]
+                - button [ref=f2e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f2e20]:
+          - generic [ref=f2e22]:
+            - link " 新規会員登録" [ref=f2e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f2e25]: 
+              - generic [ref=f2e26]: 新規会員登録
+            - link " お気に入り" [ref=f2e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f2e29]: 
+              - generic [ref=f2e30]: お気に入り
+            - link " ログイン" [ref=f2e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f2e33]: 
+              - generic [ref=f2e34]: ログイン
+          - generic [ref=f2e37] [cursor=pointer]:
+            - generic [ref=f2e38]:
+              - text: 
+              - generic [ref=f2e39]: "1"
+            - generic [ref=f2e41]: ￥3,080
+      - heading "EC-CUBE SHOP" [level=1] [ref=f2e46]:
+        - link "EC-CUBE SHOP" [ref=f2e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f2e50]:
+        - listitem [ref=f2e51]:
+          - link "新入荷" [ref=f2e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f2e53]:
+          - link "ジェラート" [ref=f2e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f2e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f2e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f2e57]:
+          - link "アイスサンド" [ref=f2e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f2e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f2e61]:
+      - heading "ショッピングカート" [level=1] [ref=f2e64]
+      - generic [ref=f2e65]:
+        - list [ref=f2e67]:
+          - listitem [ref=f2e68]:
+            - generic [ref=f2e69]: "1"
+            - generic [ref=f2e70]: カートの商品
+          - listitem [ref=f2e71]:
+            - generic [ref=f2e72]: "2"
+            - generic [ref=f2e73]: お客様情報
+          - listitem [ref=f2e74]:
+            - generic [ref=f2e75]: "3"
+            - generic [ref=f2e76]: ご注文手続き
+          - listitem [ref=f2e77]:
+            - generic [ref=f2e78]: "4"
+            - generic [ref=f2e79]: ご注文内容確認
+          - listitem [ref=f2e80]:
+            - generic [ref=f2e81]: "5"
+            - generic [ref=f2e82]: 完了
+        - paragraph [ref=f2e84]:
+          - text: 商品の合計金額は「
+          - strong [ref=f2e85]: ￥3,080
+          - text: 」です。
+        - generic [ref=f2e86]:
+          - generic [ref=f2e88]:
+            - list [ref=f2e89]:
+              - listitem [ref=f2e90]: 削除
+              - listitem [ref=f2e91]: 商品内容
+              - listitem [ref=f2e92]: 数量
+              - listitem [ref=f2e93]: 小計
+            - list [ref=f2e94]:
+              - listitem [ref=f2e95]:
+                - link "delete" [ref=f2e96] [cursor=pointer]:
+                  - /url: http://localhost:8080/cart/remove/11
+                  - img "delete" [ref=f2e97]
+              - listitem [ref=f2e98]:
+                - link "チェリーアイスサンド" [ref=f2e100] [cursor=pointer]:
+                  - /url: http://localhost:8080/products/detail/2
+                  - img "チェリーアイスサンド" [ref=f2e101]
+                - generic [ref=f2e102]:
+                  - link "チェリーアイスサンド" [ref=f2e104] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/detail/2
+                  - generic [ref=f2e105]: ￥3,080
+              - listitem [ref=f2e106]:
+                - generic [ref=f2e107]: "1"
+                - generic [ref=f2e108]:
+                  - img "reduce" [ref=f2e110]
+                  - link "increase" [ref=f2e111] [cursor=pointer]:
+                    - /url: http://localhost:8080/cart/up/11
+                    - img "increase" [ref=f2e112]
+              - listitem [ref=f2e113]:
+                - generic [ref=f2e114]: ￥3,080
+          - generic [ref=f2e115]:
+            - generic [ref=f2e116]: 合計：￥3,080
+            - link "レジに進む" [ref=f2e117] [cursor=pointer]:
+              - /url: /cart/buystep/irpIBfbMneo2WP42An92DgZJnMH15rpo_1
+            - link "お買い物を続ける" [ref=f2e118] [cursor=pointer]:
+              - /url: /
+    - contentinfo [ref=f2e119]:
+      - generic [ref=f2e121]:
+        - list [ref=f2e122]:
+          - listitem [ref=f2e123]:
+            - link "当サイトについて" [ref=f2e124] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f2e125]:
+            - link "プライバシーポリシー" [ref=f2e126] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f2e127]:
+            - link "特定商取引法に基づく表記" [ref=f2e128] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f2e129]:
+            - link "お問い合わせ" [ref=f2e130] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f2e131]:
+          - link "EC-CUBE SHOP" [ref=f2e133] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f2e134]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f2e135]:
+    - generic [ref=f2e138]:
+      - link "200 @ cart" [ref=f2e140] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d0c8b2?panel=request
+        - generic [ref=f2e141]:
+          - generic [ref=f2e142]: "200"
+          - generic [ref=f2e143]: "@"
+          - generic [ref=f2e144]: cart
+      - link "136 ms" [ref=f2e146] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d0c8b2?panel=time
+        - generic [ref=f2e147]:
+          - generic [ref=f2e148]: "136"
+          - generic [ref=f2e149]: ms
+      - link "12.0 MiB" [ref=f2e151] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d0c8b2?panel=time
+        - generic [ref=f2e152]:
+          - generic [ref=f2e153]: "12.0"
+          - generic [ref=f2e154]: MiB
+      - link "Cache 1" [ref=f2e156] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d0c8b2?panel=form
+        - generic [ref=f2e157]:
+          - img "Cache" [ref=f2e158]
+          - generic [ref=f2e164]: "1"
+      - link "Logger 484" [ref=f2e166] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d0c8b2?panel=logger
+        - generic [ref=f2e167]:
+          - img "Logger" [ref=f2e168]
+          - generic [ref=f2e172]: "484"
+      - link "Cache 20 in 0.29 ms" [ref=f2e174] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d0c8b2?panel=cache
+        - generic [ref=f2e175]:
+          - img "Cache" [ref=f2e176]
+          - generic [ref=f2e181]: "20"
+          - generic [ref=f2e182]: in 0.29 ms
+      - link "36" [ref=f2e184] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d0c8b2?panel=translation
+        - generic [ref=f2e185]:
+          - img [ref=f2e186]
+          - generic [ref=f2e191]: "36"
+      - link "Security n/a" [ref=f2e193] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d0c8b2?panel=security
+        - generic [ref=f2e194]:
+          - img "Security" [ref=f2e195]
+          - generic [ref=f2e199]: n/a
+      - link "Twig 31 ms" [ref=f2e201] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d0c8b2?panel=twig
+        - generic [ref=f2e202]:
+          - img "Twig" [ref=f2e203]
+          - generic [ref=f2e207]: "31"
+          - generic [ref=f2e208]: ms
+      - link "21 in 3.92 ms" [ref=f2e210] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d0c8b2?panel=db
+        - generic [ref=f2e211]:
+          - img [ref=f2e212]
+          - generic [ref=f2e217]: "21"
+          - generic [ref=f2e218]: in 3.92 ms
+      - link "22" [ref=f2e220] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d0c8b2?panel=doctrine_migrations
+        - generic [ref=f2e221]:
+          - img [ref=f2e222]
+          - generic [ref=f2e225]: "22"
+      - link "Symfony 7.4.13" [ref=f2e227] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d0c8b2?panel=config
+        - generic [ref=f2e228]:
+          - img "Symfony" [ref=f2e230]
+          - generic [ref=f2e232]: 7.4.13
+      - generic [ref=f2e234]:
+        - img "eccube_logo_basic" [ref=f2e235]
+        - generic [ref=f2e240]: 4.3.1-p1
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f2e241] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f2e242]:
+          - img [ref=f2e243]

--- a/.playwright-mcp/page-2026-07-03T06-11-16-212Z.yml
+++ b/.playwright-mcp/page-2026-07-03T06-11-16-212Z.yml
@@ -1,0 +1,182 @@
+- generic [ref=f3e1]:
+  - generic [ref=f3e3]:
+    - img [ref=f3e5]
+    - text: デバッグモードが有効になっています。
+  - generic [ref=f3e6]:
+    - banner [ref=f3e7]:
+      - generic [ref=f3e8]:
+        - generic [ref=f3e9]:
+          - generic [ref=f3e11]:
+            - generic:
+              - combobox [ref=f3e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f3e16]:
+                - searchbox "キーワードを入力" [ref=f3e17]
+                - button [ref=f3e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f3e20]:
+          - generic [ref=f3e22]:
+            - link " 新規会員登録" [ref=f3e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f3e25]: 
+              - generic [ref=f3e26]: 新規会員登録
+            - link " お気に入り" [ref=f3e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f3e29]: 
+              - generic [ref=f3e30]: お気に入り
+            - link " ログイン" [ref=f3e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f3e33]: 
+              - generic [ref=f3e34]: ログイン
+          - generic [ref=f3e37] [cursor=pointer]:
+            - generic [ref=f3e38]:
+              - text: 
+              - generic [ref=f3e39]: "1"
+            - generic [ref=f3e41]: ￥3,080
+      - heading "EC-CUBE SHOP" [level=1] [ref=f3e46]:
+        - link "EC-CUBE SHOP" [ref=f3e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f3e50]:
+        - listitem [ref=f3e51]:
+          - link "新入荷" [ref=f3e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f3e53]:
+          - link "ジェラート" [ref=f3e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f3e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f3e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f3e57]:
+          - link "アイスサンド" [ref=f3e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f3e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f3e61]:
+      - heading "ログイン" [level=1] [ref=f3e64]
+      - generic [ref=f3e66]:
+        - generic [ref=f3e69]:
+          - generic [ref=f3e72]:
+            - generic [ref=f3e73]:
+              - textbox "メールアドレス" [active] [ref=f3e74]
+              - textbox "パスワード" [ref=f3e75]
+            - generic [ref=f3e78]:
+              - checkbox "次回から自動的にログインする" [ref=f3e79]
+              - generic [ref=f3e80]: 次回から自動的にログインする
+          - generic [ref=f3e81]:
+            - button "ログイン" [ref=f3e84] [cursor=pointer]
+            - generic [ref=f3e85]:
+              - link "ログイン情報をお忘れですか？" [ref=f3e87] [cursor=pointer]:
+                - /url: http://localhost:8080/forgot
+              - link "新規会員登録" [ref=f3e89] [cursor=pointer]:
+                - /url: http://localhost:8080/entry
+        - generic [ref=f3e92]:
+          - paragraph [ref=f3e93]: 会員登録をせずに購入手続きをされたい方は、下記よりお進みください。
+          - link "ゲスト購入" [ref=f3e95] [cursor=pointer]:
+            - /url: http://localhost:8080/shopping/nonmember
+    - contentinfo [ref=f3e96]:
+      - generic [ref=f3e98]:
+        - list [ref=f3e99]:
+          - listitem [ref=f3e100]:
+            - link "当サイトについて" [ref=f3e101] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f3e102]:
+            - link "プライバシーポリシー" [ref=f3e103] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f3e104]:
+            - link "特定商取引法に基づく表記" [ref=f3e105] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f3e106]:
+            - link "お問い合わせ" [ref=f3e107] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f3e108]:
+          - link "EC-CUBE SHOP" [ref=f3e110] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f3e111]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f3e112]:
+    - generic [ref=f3e115]:
+      - link "200 Redirect @ shopping_login" [ref=f3e117] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a8ead?panel=request
+        - generic [ref=f3e118]:
+          - generic [ref=f3e119]: "200"
+          - img "Redirect" [ref=f3e121]
+          - generic [ref=f3e124]: "@"
+          - generic [ref=f3e125]: shopping_login
+      - link "98 ms" [ref=f3e127] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a8ead?panel=time
+        - generic [ref=f3e128]:
+          - generic [ref=f3e129]: "98"
+          - generic [ref=f3e130]: ms
+      - link "12.0 MiB" [ref=f3e132] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a8ead?panel=time
+        - generic [ref=f3e133]:
+          - generic [ref=f3e134]: "12.0"
+          - generic [ref=f3e135]: MiB
+      - link "Cache 1" [ref=f3e137] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a8ead?panel=form
+        - generic [ref=f3e138]:
+          - img "Cache" [ref=f3e139]
+          - generic [ref=f3e145]: "1"
+      - link "Logger 483" [ref=f3e147] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a8ead?panel=logger
+        - generic [ref=f3e148]:
+          - img "Logger" [ref=f3e149]
+          - generic [ref=f3e153]: "483"
+      - link "Cache 20 in 0.25 ms" [ref=f3e155] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a8ead?panel=cache
+        - generic [ref=f3e156]:
+          - img "Cache" [ref=f3e157]
+          - generic [ref=f3e162]: "20"
+          - generic [ref=f3e163]: in 0.25 ms
+      - link "3" [ref=f3e165] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a8ead?panel=translation
+        - generic [ref=f3e166]:
+          - img [ref=f3e167]
+          - generic [ref=f3e172]: "3"
+      - link "Security n/a" [ref=f3e174] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a8ead?panel=security
+        - generic [ref=f3e175]:
+          - img "Security" [ref=f3e176]
+          - generic [ref=f3e180]: n/a
+      - link "Twig 37 ms" [ref=f3e182] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a8ead?panel=twig
+        - generic [ref=f3e183]:
+          - img "Twig" [ref=f3e184]
+          - generic [ref=f3e188]: "37"
+          - generic [ref=f3e189]: ms
+      - link "19 in 3.21 ms" [ref=f3e191] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a8ead?panel=db
+        - generic [ref=f3e192]:
+          - img [ref=f3e193]
+          - generic [ref=f3e198]: "19"
+          - generic [ref=f3e199]: in 3.21 ms
+      - link "22" [ref=f3e201] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a8ead?panel=doctrine_migrations
+        - generic [ref=f3e202]:
+          - img [ref=f3e203]
+          - generic [ref=f3e206]: "22"
+      - link "Symfony 7.4.13" [ref=f3e208] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a8ead?panel=config
+        - generic [ref=f3e209]:
+          - img "Symfony" [ref=f3e211]
+          - generic [ref=f3e213]: 7.4.13
+      - generic [ref=f3e215]:
+        - img "eccube_logo_basic" [ref=f3e216]
+        - generic [ref=f3e221]: 4.3.1-p1
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f3e222] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f3e223]:
+          - img [ref=f3e224]

--- a/.playwright-mcp/page-2026-07-03T06-11-29-081Z.yml
+++ b/.playwright-mcp/page-2026-07-03T06-11-29-081Z.yml
@@ -1,0 +1,281 @@
+- generic [active] [ref=f4e1]:
+  - generic [ref=f4e3]:
+    - img [ref=f4e5]
+    - text: デバッグモードが有効になっています。
+  - generic [ref=f4e6]:
+    - banner [ref=f4e7]:
+      - generic [ref=f4e8]:
+        - generic [ref=f4e9]:
+          - generic [ref=f4e11]:
+            - generic:
+              - combobox [ref=f4e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f4e16]:
+                - searchbox "キーワードを入力" [ref=f4e17]
+                - button [ref=f4e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f4e20]:
+          - generic [ref=f4e22]:
+            - link " 新規会員登録" [ref=f4e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f4e25]: 
+              - generic [ref=f4e26]: 新規会員登録
+            - link " お気に入り" [ref=f4e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f4e29]: 
+              - generic [ref=f4e30]: お気に入り
+            - link " ログイン" [ref=f4e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f4e33]: 
+              - generic [ref=f4e34]: ログイン
+          - generic [ref=f4e37] [cursor=pointer]:
+            - generic [ref=f4e38]:
+              - text: 
+              - generic [ref=f4e39]: "1"
+            - generic [ref=f4e41]: ￥3,080
+      - heading "EC-CUBE SHOP" [level=1] [ref=f4e46]:
+        - link "EC-CUBE SHOP" [ref=f4e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f4e50]:
+        - listitem [ref=f4e51]:
+          - link "新入荷" [ref=f4e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f4e53]:
+          - link "ジェラート" [ref=f4e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f4e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f4e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f4e57]:
+          - link "アイスサンド" [ref=f4e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f4e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f4e61]:
+      - generic [ref=f4e62]:
+        - heading "お客様情報の入力" [level=1] [ref=f4e64]
+        - list [ref=f4e67]:
+          - listitem [ref=f4e68]:
+            - generic [ref=f4e69]: "1"
+            - generic [ref=f4e70]: カートの商品
+          - listitem [ref=f4e71]:
+            - generic [ref=f4e72]: "2"
+            - generic [ref=f4e73]: お客様情報
+          - listitem [ref=f4e74]:
+            - generic [ref=f4e75]: "3"
+            - generic [ref=f4e76]: ご注文手続き
+          - listitem [ref=f4e77]:
+            - generic [ref=f4e78]: "4"
+            - generic [ref=f4e79]: ご注文内容確認
+          - listitem [ref=f4e80]:
+            - generic [ref=f4e81]: "5"
+            - generic [ref=f4e82]: 完了
+        - generic [ref=f4e85]:
+          - generic [ref=f4e86]:
+            - generic [ref=f4e87]:
+              - term [ref=f4e88]:
+                - generic [ref=f4e89]: お名前
+                - generic [ref=f4e90]: 必須
+              - definition [ref=f4e91]:
+                - generic [ref=f4e92]:
+                  - textbox "姓" [ref=f4e93]
+                  - textbox "名" [ref=f4e94]
+            - generic [ref=f4e95]:
+              - term [ref=f4e96]:
+                - generic [ref=f4e97]: お名前(カナ)
+                - generic [ref=f4e98]: 必須
+              - definition [ref=f4e99]:
+                - generic [ref=f4e100]:
+                  - textbox "セイ" [ref=f4e101]
+                  - textbox "メイ" [ref=f4e102]
+            - generic [ref=f4e103]:
+              - term [ref=f4e104]:
+                - generic [ref=f4e105]: 会社名
+              - definition [ref=f4e106]:
+                - textbox "会社名" [ref=f4e108]
+            - generic [ref=f4e109]:
+              - term [ref=f4e110]:
+                - generic [ref=f4e111]: 住所
+                - generic [ref=f4e112]: 必須
+              - definition [ref=f4e113]:
+                - generic [ref=f4e114]:
+                  - generic [ref=f4e115]: 〒
+                  - textbox "例：5300001" [ref=f4e116]
+                  - link "郵便番号検索" [ref=f4e120] [cursor=pointer]:
+                    - /url: https://www.post.japanpost.jp/zipcode/
+                    - generic: 郵便番号検索
+                - combobox [ref=f4e122]:
+                  - option "都道府県を選択" [selected]
+                  - option "北海道"
+                  - option "青森県"
+                  - option "岩手県"
+                  - option "宮城県"
+                  - option "秋田県"
+                  - option "山形県"
+                  - option "福島県"
+                  - option "茨城県"
+                  - option "栃木県"
+                  - option "群馬県"
+                  - option "埼玉県"
+                  - option "千葉県"
+                  - option "東京都"
+                  - option "神奈川県"
+                  - option "新潟県"
+                  - option "富山県"
+                  - option "石川県"
+                  - option "福井県"
+                  - option "山梨県"
+                  - option "長野県"
+                  - option "岐阜県"
+                  - option "静岡県"
+                  - option "愛知県"
+                  - option "三重県"
+                  - option "滋賀県"
+                  - option "京都府"
+                  - option "大阪府"
+                  - option "兵庫県"
+                  - option "奈良県"
+                  - option "和歌山県"
+                  - option "鳥取県"
+                  - option "島根県"
+                  - option "岡山県"
+                  - option "広島県"
+                  - option "山口県"
+                  - option "徳島県"
+                  - option "香川県"
+                  - option "愛媛県"
+                  - option "高知県"
+                  - option "福岡県"
+                  - option "佐賀県"
+                  - option "長崎県"
+                  - option "熊本県"
+                  - option "大分県"
+                  - option "宮崎県"
+                  - option "鹿児島県"
+                  - option "沖縄県"
+                - textbox "市区町村名(例：大阪市北区)" [ref=f4e124]
+                - textbox "番地・ビル名(例：西梅田1丁目6-8)" [ref=f4e126]
+            - generic [ref=f4e127]:
+              - term [ref=f4e128]:
+                - generic [ref=f4e129]: 電話番号
+                - generic [ref=f4e130]: 必須
+              - definition [ref=f4e131]:
+                - textbox "電話番号" [ref=f4e133]:
+                  - /placeholder: 例：11122223333
+            - generic [ref=f4e134]:
+              - term [ref=f4e135]:
+                - generic [ref=f4e136]: メールアドレス
+                - generic [ref=f4e137]: 必須
+              - definition [ref=f4e138]:
+                - textbox "例：ec-cube@example.com" [ref=f4e140]
+                - textbox "確認のためもう一度入力してください" [ref=f4e142]
+          - generic [ref=f4e145]:
+            - button "次へ" [ref=f4e146] [cursor=pointer]
+            - link "戻る" [ref=f4e147] [cursor=pointer]:
+              - /url: http://localhost:8080/cart
+    - contentinfo [ref=f4e148]:
+      - generic [ref=f4e150]:
+        - list [ref=f4e151]:
+          - listitem [ref=f4e152]:
+            - link "当サイトについて" [ref=f4e153] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f4e154]:
+            - link "プライバシーポリシー" [ref=f4e155] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f4e156]:
+            - link "特定商取引法に基づく表記" [ref=f4e157] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f4e158]:
+            - link "お問い合わせ" [ref=f4e159] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f4e160]:
+          - link "EC-CUBE SHOP" [ref=f4e162] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f4e163]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f4e164]:
+    - generic [ref=f4e167]:
+      - link "200 @ shopping_nonmember" [ref=f4e169] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/3ebea7?panel=request
+        - generic [ref=f4e170]:
+          - generic [ref=f4e171]: "200"
+          - generic [ref=f4e172]: "@"
+          - generic [ref=f4e173]: shopping_nonmember
+      - link "162 ms" [ref=f4e175] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/3ebea7?panel=time
+        - generic [ref=f4e176]:
+          - generic [ref=f4e177]: "162"
+          - generic [ref=f4e178]: ms
+      - link "14.0 MiB" [ref=f4e180] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/3ebea7?panel=time
+        - generic [ref=f4e181]:
+          - generic [ref=f4e182]: "14.0"
+          - generic [ref=f4e183]: MiB
+      - link "Cache 2" [ref=f4e185] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/3ebea7?panel=form
+        - generic [ref=f4e186]:
+          - img "Cache" [ref=f4e187]
+          - generic [ref=f4e193]: "2"
+      - link "Logger 517" [ref=f4e195] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/3ebea7?panel=logger
+        - generic [ref=f4e196]:
+          - img "Logger" [ref=f4e197]
+          - generic [ref=f4e201]: "517"
+      - link "Cache 23 in 0.36 ms" [ref=f4e203] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/3ebea7?panel=cache
+        - generic [ref=f4e204]:
+          - img "Cache" [ref=f4e205]
+          - generic [ref=f4e210]: "23"
+          - generic [ref=f4e211]: in 0.36 ms
+      - link "48" [ref=f4e213] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/3ebea7?panel=translation
+        - generic [ref=f4e214]:
+          - img [ref=f4e215]
+          - generic [ref=f4e220]: "48"
+      - link "Security n/a" [ref=f4e222] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/3ebea7?panel=security
+        - generic [ref=f4e223]:
+          - img "Security" [ref=f4e224]
+          - generic [ref=f4e228]: n/a
+      - link "Twig 53 ms" [ref=f4e230] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/3ebea7?panel=twig
+        - generic [ref=f4e231]:
+          - img "Twig" [ref=f4e232]
+          - generic [ref=f4e236]: "53"
+          - generic [ref=f4e237]: ms
+      - link "20 in 5.50 ms" [ref=f4e239] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/3ebea7?panel=db
+        - generic [ref=f4e240]:
+          - img [ref=f4e241]
+          - generic [ref=f4e246]: "20"
+          - generic [ref=f4e247]: in 5.50 ms
+      - link "22" [ref=f4e249] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/3ebea7?panel=doctrine_migrations
+        - generic [ref=f4e250]:
+          - img [ref=f4e251]
+          - generic [ref=f4e254]: "22"
+      - link "Symfony 7.4.13" [ref=f4e256] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/3ebea7?panel=config
+        - generic [ref=f4e257]:
+          - img "Symfony" [ref=f4e259]
+          - generic [ref=f4e261]: 7.4.13
+      - generic [ref=f4e263]:
+        - img "eccube_logo_basic" [ref=f4e264]
+        - generic [ref=f4e269]: 4.3.1-p1
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f4e270] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f4e271]:
+          - img [ref=f4e272]

--- a/.playwright-mcp/page-2026-07-03T06-12-11-182Z.yml
+++ b/.playwright-mcp/page-2026-07-03T06-12-11-182Z.yml
@@ -1,0 +1,271 @@
+- generic [active] [ref=f5e1]:
+  - generic [ref=f5e3]:
+    - img [ref=f5e5]
+    - text: デバッグモードが有効になっています。
+  - generic [ref=f5e6]:
+    - banner [ref=f5e7]:
+      - generic [ref=f5e8]:
+        - generic [ref=f5e9]:
+          - generic [ref=f5e11]:
+            - generic:
+              - combobox [ref=f5e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f5e16]:
+                - searchbox "キーワードを入力" [ref=f5e17]
+                - button [ref=f5e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f5e20]:
+          - generic [ref=f5e22]:
+            - link " 新規会員登録" [ref=f5e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f5e25]: 
+              - generic [ref=f5e26]: 新規会員登録
+            - link " お気に入り" [ref=f5e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f5e29]: 
+              - generic [ref=f5e30]: お気に入り
+            - link " ログイン" [ref=f5e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f5e33]: 
+              - generic [ref=f5e34]: ログイン
+          - generic [ref=f5e37] [cursor=pointer]:
+            - generic [ref=f5e38]:
+              - text: 
+              - generic [ref=f5e39]: "1"
+            - generic [ref=f5e41]: ￥3,080
+      - heading "EC-CUBE SHOP" [level=1] [ref=f5e46]:
+        - link "EC-CUBE SHOP" [ref=f5e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f5e50]:
+        - listitem [ref=f5e51]:
+          - link "新入荷" [ref=f5e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f5e53]:
+          - link "ジェラート" [ref=f5e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f5e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f5e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f5e57]:
+          - link "アイスサンド" [ref=f5e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f5e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f5e61]:
+      - heading "ご注文手続き" [level=1] [ref=f5e64]
+      - list [ref=f5e67]:
+        - listitem [ref=f5e68]:
+          - generic [ref=f5e69]: "1"
+          - generic [ref=f5e70]: カートの商品
+        - listitem [ref=f5e71]:
+          - generic [ref=f5e72]: "2"
+          - generic [ref=f5e73]: お客様情報
+        - listitem [ref=f5e74]:
+          - generic [ref=f5e75]: "3"
+          - generic [ref=f5e76]: ご注文手続き
+        - listitem [ref=f5e77]:
+          - generic [ref=f5e78]: "4"
+          - generic [ref=f5e79]: ご注文内容確認
+        - listitem [ref=f5e80]:
+          - generic [ref=f5e81]: "5"
+          - generic [ref=f5e82]: 完了
+      - generic [ref=f5e84]:
+        - generic [ref=f5e85]:
+          - generic [ref=f5e86]:
+            - heading "お客様情報" [level=2] [ref=f5e88]
+            - button "変更" [ref=f5e90] [cursor=pointer]
+            - generic [ref=f5e91]:
+              - paragraph [ref=f5e92]: 山田 太郎 様
+              - paragraph [ref=f5e93]: ヤマダ タロウ
+              - paragraph
+              - paragraph [ref=f5e94]:
+                - text: 〒
+                - generic [ref=f5e95]: "1000001"
+              - paragraph [ref=f5e96]: 東京都千代田区千代田1-1
+              - paragraph [ref=f5e97]: "0300000000"
+              - paragraph [ref=f5e98]: guest@example.com
+          - generic [ref=f5e99]:
+            - heading "配送情報" [level=2] [ref=f5e101]
+            - generic [ref=f5e102]:
+              - text: お届け先
+              - button "変更" [ref=f5e104] [cursor=pointer]
+            - generic [ref=f5e105]:
+              - list [ref=f5e106]:
+                - listitem [ref=f5e107]:
+                  - generic [ref=f5e108]:
+                    - img "チェリーアイスサンド" [ref=f5e110]
+                    - generic [ref=f5e111]:
+                      - paragraph [ref=f5e112]: チェリーアイスサンド
+                      - paragraph [ref=f5e113]: ￥3,080 × 1小計：￥3,080
+              - paragraph
+            - generic [ref=f5e114]:
+              - paragraph [ref=f5e115]: 山田 太郎 (ヤマダ タロウ) 様
+              - paragraph [ref=f5e116]: 〒1000001 東京都千代田区千代田1-1
+              - paragraph [ref=f5e117]: "0300000000"
+            - generic [ref=f5e119]:
+              - generic [ref=f5e120]:
+                - generic [ref=f5e121]: 配送方法
+                - combobox [ref=f5e122]:
+                  - option "サンプル業者" [selected]
+              - generic [ref=f5e123]:
+                - generic [ref=f5e124]: お届け日
+                - combobox [ref=f5e125]:
+                  - option "指定なし" [selected]
+              - generic [ref=f5e126]:
+                - generic [ref=f5e127]: お届け時間
+                - combobox [ref=f5e128]:
+                  - option "指定なし" [selected]
+                  - option "午前"
+                  - option "午後"
+            - button "お届け先を追加する" [ref=f5e130] [cursor=pointer]
+          - generic [ref=f5e131]:
+            - heading "お支払方法" [level=2] [ref=f5e133]
+            - generic [ref=f5e134]:
+              - generic [ref=f5e135]:
+                - radio "郵便振替" [checked] [ref=f5e136]
+                - generic [ref=f5e137]: 郵便振替
+              - generic [ref=f5e138]:
+                - radio "現金書留" [ref=f5e139]
+                - generic [ref=f5e140]: 現金書留
+              - generic [ref=f5e141]:
+                - radio "銀行振込" [ref=f5e142]
+                - generic [ref=f5e143]: 銀行振込
+              - generic [ref=f5e144]:
+                - radio "代金引換" [ref=f5e145]
+                - generic [ref=f5e146]: 代金引換
+          - generic [ref=f5e147]:
+            - heading "クーポン" [level=2] [ref=f5e149]
+            - generic [ref=f5e150]:
+              - text: クーポンをお持ちの方はクーポンコードを入力してください。
+              - paragraph [ref=f5e151]:
+                - link "クーポンを変更する" [ref=f5e152] [cursor=pointer]:
+                  - /url: http://localhost:8080/plugin/coupon/shopping/shopping_coupon
+          - generic [ref=f5e153]:
+            - heading "お問い合わせ" [level=2] [ref=f5e155]
+            - textbox "お問い合わせ事項がございましたら、こちらにご入力ください。(3000文字まで)" [ref=f5e157]
+        - generic [ref=f5e159]:
+          - generic [ref=f5e160]:
+            - term [ref=f5e161]: 小計
+            - definition [ref=f5e162]: ￥3,080
+          - generic [ref=f5e163]:
+            - term [ref=f5e164]: 手数料
+            - definition [ref=f5e165]: ￥0
+          - generic [ref=f5e166]:
+            - term [ref=f5e167]: 送料
+            - definition [ref=f5e168]: ￥1,000
+          - generic [ref=f5e169]: 合計￥4,080税込
+          - generic [ref=f5e170]: お支払い合計￥4,080税込
+          - generic [ref=f5e171]:
+            - term [ref=f5e172]: "[ 税率 10 %対象"
+            - definition [ref=f5e173]: ￥4,080 (内消費税 ￥371) ]
+          - generic [ref=f5e174]:
+            - button "確認する" [ref=f5e175] [cursor=pointer]
+            - link "カートに戻る" [ref=f5e176] [cursor=pointer]:
+              - /url: http://localhost:8080/cart
+    - contentinfo [ref=f5e177]:
+      - generic [ref=f5e179]:
+        - list [ref=f5e180]:
+          - listitem [ref=f5e181]:
+            - link "当サイトについて" [ref=f5e182] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f5e183]:
+            - link "プライバシーポリシー" [ref=f5e184] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f5e185]:
+            - link "特定商取引法に基づく表記" [ref=f5e186] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f5e187]:
+            - link "お問い合わせ" [ref=f5e188] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f5e189]:
+          - link "EC-CUBE SHOP" [ref=f5e191] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f5e192]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f5e193]:
+    - generic [ref=f5e196]:
+      - link "200 Redirect @ shopping" [ref=f5e198] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1bea7e?panel=request
+        - generic [ref=f5e199]:
+          - generic [ref=f5e200]: "200"
+          - img "Redirect" [ref=f5e202]
+          - generic [ref=f5e205]: "@"
+          - generic [ref=f5e206]: shopping
+      - link "447 ms" [ref=f5e208] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1bea7e?panel=time
+        - generic [ref=f5e209]:
+          - generic [ref=f5e210]: "447"
+          - generic [ref=f5e211]: ms
+      - link "14.0 MiB" [ref=f5e213] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1bea7e?panel=time
+        - generic [ref=f5e214]:
+          - generic [ref=f5e215]: "14.0"
+          - generic [ref=f5e216]: MiB
+      - link "Cache 2" [ref=f5e218] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1bea7e?panel=form
+        - generic [ref=f5e219]:
+          - img "Cache" [ref=f5e220]
+          - generic [ref=f5e226]: "2"
+      - link "Logger 491" [ref=f5e228] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1bea7e?panel=logger
+        - generic [ref=f5e229]:
+          - img "Logger" [ref=f5e230]
+          - generic [ref=f5e234]: "491"
+      - link "Cache 28 in 0.76 ms" [ref=f5e236] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1bea7e?panel=cache
+        - generic [ref=f5e237]:
+          - img "Cache" [ref=f5e238]
+          - generic [ref=f5e243]: "28"
+          - generic [ref=f5e244]: in 0.76 ms
+      - link "1" [ref=f5e246] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1bea7e?panel=translation
+        - generic [ref=f5e247]:
+          - img [ref=f5e248]
+          - generic [ref=f5e253]: "1"
+      - link "Security n/a" [ref=f5e255] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1bea7e?panel=security
+        - generic [ref=f5e256]:
+          - img "Security" [ref=f5e257]
+          - generic [ref=f5e261]: n/a
+      - link "Twig 71 ms" [ref=f5e263] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1bea7e?panel=twig
+        - generic [ref=f5e264]:
+          - img "Twig" [ref=f5e265]
+          - generic [ref=f5e269]: "71"
+          - generic [ref=f5e270]: ms
+      - link "49 in 33.60 ms" [ref=f5e272] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1bea7e?panel=db
+        - generic [ref=f5e273]:
+          - img [ref=f5e274]
+          - generic [ref=f5e279]: "49"
+          - generic [ref=f5e280]: in 33.60 ms
+      - link "22" [ref=f5e282] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1bea7e?panel=doctrine_migrations
+        - generic [ref=f5e283]:
+          - img [ref=f5e284]
+          - generic [ref=f5e287]: "22"
+      - link "Symfony 7.4.13" [ref=f5e289] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1bea7e?panel=config
+        - generic [ref=f5e290]:
+          - img "Symfony" [ref=f5e292]
+          - generic [ref=f5e294]: 7.4.13
+      - generic [ref=f5e296]:
+        - img "eccube_logo_basic" [ref=f5e297]
+        - generic [ref=f5e302]: 4.3.1-p1
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f5e303] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f5e304]:
+          - img [ref=f5e305]

--- a/.playwright-mcp/page-2026-07-03T06-12-26-886Z.yml
+++ b/.playwright-mcp/page-2026-07-03T06-12-26-886Z.yml
@@ -1,0 +1,122 @@
+- generic [active] [ref=f6e1]:
+  - generic [ref=f6e3]:
+    - img [ref=f6e5]
+    - text: デバッグモードが有効になっています。
+  - generic [ref=f6e6]:
+    - banner [ref=f6e7]:
+      - generic [ref=f6e8]:
+        - generic [ref=f6e9]:
+          - generic [ref=f6e11]:
+            - generic:
+              - combobox [ref=f6e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f6e16]:
+                - searchbox "キーワードを入力" [ref=f6e17]
+                - button [ref=f6e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f6e20]:
+          - generic [ref=f6e22]:
+            - link " 新規会員登録" [ref=f6e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f6e25]: 
+              - generic [ref=f6e26]: 新規会員登録
+            - link " お気に入り" [ref=f6e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f6e29]: 
+              - generic [ref=f6e30]: お気に入り
+            - link " ログイン" [ref=f6e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f6e33]: 
+              - generic [ref=f6e34]: ログイン
+          - generic [ref=f6e37] [cursor=pointer]:
+            - generic [ref=f6e38]:
+              - text: 
+              - generic [ref=f6e39]: "1"
+            - generic [ref=f6e41]: ￥3,080
+      - heading "EC-CUBE SHOP" [level=1] [ref=f6e46]:
+        - link "EC-CUBE SHOP" [ref=f6e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f6e50]:
+        - listitem [ref=f6e51]:
+          - link "新入荷" [ref=f6e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f6e53]:
+          - link "ジェラート" [ref=f6e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f6e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f6e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f6e57]:
+          - link "アイスサンド" [ref=f6e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f6e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f6e61]:
+      - heading "クーポンコードの入力" [level=1] [ref=f6e64]
+      - generic [ref=f6e67]:
+        - generic [ref=f6e69]: 利用するクーポンコードを入力してください。
+        - generic [ref=f6e70]:
+          - generic [ref=f6e71]:
+            - generic [ref=f6e72]:
+              - term [ref=f6e73]
+              - definition [ref=f6e74]:
+                - generic [ref=f6e75]:
+                  - generic [ref=f6e76]:
+                    - radio "クーポンを利用しない" [ref=f6e77]
+                    - generic [ref=f6e78]: クーポンを利用しない
+                  - generic [ref=f6e79]:
+                    - radio "クーポンを利用する" [checked] [ref=f6e80]
+                    - generic [ref=f6e81]: クーポンを利用する
+            - generic [ref=f6e82]:
+              - term [ref=f6e83]:
+                - generic [ref=f6e84]: クーポンコード
+              - definition [ref=f6e85]:
+                - textbox "クーポンコード" [ref=f6e86]
+          - generic [ref=f6e89]:
+            - button "登録する" [ref=f6e90] [cursor=pointer]
+            - link "戻る" [ref=f6e91] [cursor=pointer]:
+              - /url: http://localhost:8080/shopping
+    - contentinfo [ref=f6e92]:
+      - generic [ref=f6e94]:
+        - list [ref=f6e95]:
+          - listitem [ref=f6e96]:
+            - link "当サイトについて" [ref=f6e97] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f6e98]:
+            - link "プライバシーポリシー" [ref=f6e99] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f6e100]:
+            - link "特定商取引法に基づく表記" [ref=f6e101] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f6e102]:
+            - link "お問い合わせ" [ref=f6e103] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f6e104]:
+          - link "EC-CUBE SHOP" [ref=f6e106] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f6e107]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f6e108]:
+    - generic [ref=f6e111]:
+      - link "Symfony Loading…" [ref=f6e113] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d4a6de?panel=request
+        - generic [ref=f6e114]:
+          - img "Symfony" [ref=f6e115]
+          - generic [ref=f6e117]: Loading…
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f6e118] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f6e119]:
+          - img [ref=f6e120]

--- a/.playwright-mcp/page-2026-07-03T06-12-51-021Z.yml
+++ b/.playwright-mcp/page-2026-07-03T06-12-51-021Z.yml
@@ -1,0 +1,184 @@
+- generic [ref=f6e1]:
+  - generic [ref=f6e3]:
+    - img [ref=f6e5]
+    - text: デバッグモードが有効になっています。
+  - generic [ref=f6e6]:
+    - banner [ref=f6e7]:
+      - generic [ref=f6e8]:
+        - generic [ref=f6e9]:
+          - generic [ref=f6e11]:
+            - generic:
+              - combobox [ref=f6e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f6e16]:
+                - searchbox "キーワードを入力" [ref=f6e17]
+                - button [ref=f6e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f6e20]:
+          - generic [ref=f6e22]:
+            - link " 新規会員登録" [ref=f6e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f6e25]: 
+              - generic [ref=f6e26]: 新規会員登録
+            - link " お気に入り" [ref=f6e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f6e29]: 
+              - generic [ref=f6e30]: お気に入り
+            - link " ログイン" [ref=f6e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f6e33]: 
+              - generic [ref=f6e34]: ログイン
+          - generic [ref=f6e37] [cursor=pointer]:
+            - generic [ref=f6e38]:
+              - text: 
+              - generic [ref=f6e39]: "1"
+            - generic [ref=f6e41]: ￥3,080
+      - heading "EC-CUBE SHOP" [level=1] [ref=f6e46]:
+        - link "EC-CUBE SHOP" [ref=f6e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f6e50]:
+        - listitem [ref=f6e51]:
+          - link "新入荷" [ref=f6e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f6e53]:
+          - link "ジェラート" [ref=f6e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f6e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f6e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f6e57]:
+          - link "アイスサンド" [ref=f6e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f6e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f6e61]:
+      - heading "クーポンコードの入力" [level=1] [ref=f6e64]
+      - generic [ref=f6e67]:
+        - generic [ref=f6e69]: 利用するクーポンコードを入力してください。
+        - generic [ref=f6e70]:
+          - generic [ref=f6e71]:
+            - generic [ref=f6e72]:
+              - term [ref=f6e73]
+              - definition [ref=f6e74]:
+                - generic [ref=f6e75]:
+                  - generic [ref=f6e76]:
+                    - radio "クーポンを利用しない" [checked] [active] [ref=f6e77]
+                    - generic [ref=f6e78]: クーポンを利用しない
+                  - generic [ref=f6e79]:
+                    - radio "クーポンを利用する" [ref=f6e80]
+                    - generic [ref=f6e81]: クーポンを利用する
+            - generic [ref=f6e82]:
+              - term [ref=f6e83]:
+                - generic [ref=f6e84]: クーポンコード
+              - definition [ref=f6e85]:
+                - textbox "クーポンコード" [ref=f6e86]
+          - generic [ref=f6e89]:
+            - button "登録する" [ref=f6e90] [cursor=pointer]
+            - link "戻る" [ref=f6e91] [cursor=pointer]:
+              - /url: http://localhost:8080/shopping
+    - contentinfo [ref=f6e92]:
+      - generic [ref=f6e94]:
+        - list [ref=f6e95]:
+          - listitem [ref=f6e96]:
+            - link "当サイトについて" [ref=f6e97] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f6e98]:
+            - link "プライバシーポリシー" [ref=f6e99] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f6e100]:
+            - link "特定商取引法に基づく表記" [ref=f6e101] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f6e102]:
+            - link "お問い合わせ" [ref=f6e103] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f6e104]:
+          - link "EC-CUBE SHOP" [ref=f6e106] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f6e107]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f6e108]:
+    - generic [ref=f6e125]:
+      - link "200 @ plugin_coupon_shopping" [ref=f6e127] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d4a6de?panel=request
+        - generic [ref=f6e128]:
+          - generic [ref=f6e129]: "200"
+          - generic [ref=f6e130]: "@"
+          - generic [ref=f6e131]: plugin_coupon_shopping
+      - link "116 ms" [ref=f6e133] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d4a6de?panel=time
+        - generic [ref=f6e134]:
+          - generic [ref=f6e135]: "116"
+          - generic [ref=f6e136]: ms
+      - link "12.0 MiB" [ref=f6e138] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d4a6de?panel=time
+        - generic [ref=f6e139]:
+          - generic [ref=f6e140]: "12.0"
+          - generic [ref=f6e141]: MiB
+      - link "Cache 2" [ref=f6e143] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d4a6de?panel=form
+        - generic [ref=f6e144]:
+          - img "Cache" [ref=f6e145]
+          - generic [ref=f6e151]: "2"
+      - link "Logger 483" [ref=f6e153] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d4a6de?panel=logger
+        - generic [ref=f6e154]:
+          - img "Logger" [ref=f6e155]
+          - generic [ref=f6e159]: "483"
+      - link "Cache 20 in 0.28 ms" [ref=f6e161] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d4a6de?panel=cache
+        - generic [ref=f6e162]:
+          - img "Cache" [ref=f6e163]
+          - generic [ref=f6e168]: "20"
+          - generic [ref=f6e169]: in 0.28 ms
+      - link "27" [ref=f6e171] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d4a6de?panel=translation
+        - generic [ref=f6e172]:
+          - img [ref=f6e173]
+          - generic [ref=f6e178]: "27"
+      - link "Security n/a" [ref=f6e180] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d4a6de?panel=security
+        - generic [ref=f6e181]:
+          - img "Security" [ref=f6e182]
+          - generic [ref=f6e186]: n/a
+      - link "Twig 37 ms" [ref=f6e188] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d4a6de?panel=twig
+        - generic [ref=f6e189]:
+          - img "Twig" [ref=f6e190]
+          - generic [ref=f6e194]: "37"
+          - generic [ref=f6e195]: ms
+      - link "21 in 3.66 ms" [ref=f6e197] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d4a6de?panel=db
+        - generic [ref=f6e198]:
+          - img [ref=f6e199]
+          - generic [ref=f6e204]: "21"
+          - generic [ref=f6e205]: in 3.66 ms
+      - link "22" [ref=f6e207] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d4a6de?panel=doctrine_migrations
+        - generic [ref=f6e208]:
+          - img [ref=f6e209]
+          - generic [ref=f6e212]: "22"
+      - link "Symfony 7.4.13" [ref=f6e214] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d4a6de?panel=config
+        - generic [ref=f6e215]:
+          - img "Symfony" [ref=f6e217]
+          - generic [ref=f6e219]: 7.4.13
+      - generic [ref=f6e221]:
+        - img "eccube_logo_basic" [ref=f6e222]
+        - generic [ref=f6e227]: 4.3.1-p1
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f6e228] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f6e229]:
+          - img [ref=f6e230]

--- a/.playwright-mcp/page-2026-07-03T06-15-54-154Z.yml
+++ b/.playwright-mcp/page-2026-07-03T06-15-54-154Z.yml
@@ -1,0 +1,184 @@
+- generic [active] [ref=f7e1]:
+  - generic [ref=f7e3]:
+    - img [ref=f7e5]
+    - text: デバッグモードが有効になっています。
+  - generic [ref=f7e6]:
+    - banner [ref=f7e7]:
+      - generic [ref=f7e8]:
+        - generic [ref=f7e9]:
+          - generic [ref=f7e11]:
+            - generic:
+              - combobox [ref=f7e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f7e16]:
+                - searchbox "キーワードを入力" [ref=f7e17]
+                - button [ref=f7e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f7e20]:
+          - generic [ref=f7e22]:
+            - link " 新規会員登録" [ref=f7e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f7e25]: 
+              - generic [ref=f7e26]: 新規会員登録
+            - link " お気に入り" [ref=f7e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f7e29]: 
+              - generic [ref=f7e30]: お気に入り
+            - link " ログイン" [ref=f7e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f7e33]: 
+              - generic [ref=f7e34]: ログイン
+          - generic [ref=f7e37] [cursor=pointer]:
+            - generic [ref=f7e38]:
+              - text: 
+              - generic [ref=f7e39]: "1"
+            - generic [ref=f7e41]: ￥3,080
+      - heading "EC-CUBE SHOP" [level=1] [ref=f7e46]:
+        - link "EC-CUBE SHOP" [ref=f7e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f7e50]:
+        - listitem [ref=f7e51]:
+          - link "新入荷" [ref=f7e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f7e53]:
+          - link "ジェラート" [ref=f7e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f7e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f7e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f7e57]:
+          - link "アイスサンド" [ref=f7e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f7e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f7e61]:
+      - heading "クーポンコードの入力" [level=1] [ref=f7e64]
+      - generic [ref=f7e67]:
+        - generic [ref=f7e69]: 利用するクーポンコードを入力してください。
+        - generic [ref=f7e70]:
+          - generic [ref=f7e71]:
+            - generic [ref=f7e72]:
+              - term [ref=f7e73]
+              - definition [ref=f7e74]:
+                - generic [ref=f7e75]:
+                  - generic [ref=f7e76]:
+                    - radio "クーポンを利用しない" [ref=f7e77]
+                    - generic [ref=f7e78]: クーポンを利用しない
+                  - generic [ref=f7e79]:
+                    - radio "クーポンを利用する" [checked] [ref=f7e80]
+                    - generic [ref=f7e81]: クーポンを利用する
+            - generic [ref=f7e82]:
+              - term [ref=f7e83]:
+                - generic [ref=f7e84]: クーポンコード
+              - definition [ref=f7e85]:
+                - textbox "クーポンコード" [ref=f7e86]
+          - generic [ref=f7e89]:
+            - button "登録する" [ref=f7e90] [cursor=pointer]
+            - link "戻る" [ref=f7e91] [cursor=pointer]:
+              - /url: http://localhost:8080/shopping
+    - contentinfo [ref=f7e92]:
+      - generic [ref=f7e94]:
+        - list [ref=f7e95]:
+          - listitem [ref=f7e96]:
+            - link "当サイトについて" [ref=f7e97] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f7e98]:
+            - link "プライバシーポリシー" [ref=f7e99] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f7e100]:
+            - link "特定商取引法に基づく表記" [ref=f7e101] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f7e102]:
+            - link "お問い合わせ" [ref=f7e103] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f7e104]:
+          - link "EC-CUBE SHOP" [ref=f7e106] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f7e107]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f7e108]:
+    - generic [ref=f7e111]:
+      - link "200 @ plugin_coupon_shopping" [ref=f7e113] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=request
+        - generic [ref=f7e114]:
+          - generic [ref=f7e115]: "200"
+          - generic [ref=f7e116]: "@"
+          - generic [ref=f7e117]: plugin_coupon_shopping
+      - link "170 ms" [ref=f7e119] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=time
+        - generic [ref=f7e120]:
+          - generic [ref=f7e121]: "170"
+          - generic [ref=f7e122]: ms
+      - link "12.0 MiB" [ref=f7e124] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=time
+        - generic [ref=f7e125]:
+          - generic [ref=f7e126]: "12.0"
+          - generic [ref=f7e127]: MiB
+      - link "Cache 2" [ref=f7e129] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=form
+        - generic [ref=f7e130]:
+          - img "Cache" [ref=f7e131]
+          - generic [ref=f7e137]: "2"
+      - link "Logger 24" [ref=f7e139] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=logger
+        - generic [ref=f7e140]:
+          - img "Logger" [ref=f7e141]
+          - generic [ref=f7e145]: "24"
+      - link "Cache 20 in 0.30 ms" [ref=f7e147] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=cache
+        - generic [ref=f7e148]:
+          - img "Cache" [ref=f7e149]
+          - generic [ref=f7e154]: "20"
+          - generic [ref=f7e155]: in 0.30 ms
+      - link "27" [ref=f7e157] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=translation
+        - generic [ref=f7e158]:
+          - img [ref=f7e159]
+          - generic [ref=f7e164]: "27"
+      - link "Security n/a" [ref=f7e166] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=security
+        - generic [ref=f7e167]:
+          - img "Security" [ref=f7e168]
+          - generic [ref=f7e172]: n/a
+      - link "Twig 57 ms" [ref=f7e174] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=twig
+        - generic [ref=f7e175]:
+          - img "Twig" [ref=f7e176]
+          - generic [ref=f7e180]: "57"
+          - generic [ref=f7e181]: ms
+      - link "21 in 3.94 ms" [ref=f7e183] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=db
+        - generic [ref=f7e184]:
+          - img [ref=f7e185]
+          - generic [ref=f7e190]: "21"
+          - generic [ref=f7e191]: in 3.94 ms
+      - link "22" [ref=f7e193] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=doctrine_migrations
+        - generic [ref=f7e194]:
+          - img [ref=f7e195]
+          - generic [ref=f7e198]: "22"
+      - link "Symfony 7.4.13" [ref=f7e200] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=config
+        - generic [ref=f7e201]:
+          - img "Symfony" [ref=f7e203]
+          - generic [ref=f7e205]: 7.4.13
+      - generic [ref=f7e207]:
+        - img "eccube_logo_basic" [ref=f7e208]
+        - generic [ref=f7e213]: 4.3.1-p1
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f7e214] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f7e215]:
+          - img [ref=f7e216]

--- a/.playwright-mcp/page-2026-07-03T06-16-00-407Z.yml
+++ b/.playwright-mcp/page-2026-07-03T06-16-00-407Z.yml
@@ -1,0 +1,184 @@
+- generic [ref=f7e1]:
+  - generic [ref=f7e3]:
+    - img [ref=f7e5]
+    - text: デバッグモードが有効になっています。
+  - generic [ref=f7e6]:
+    - banner [ref=f7e7]:
+      - generic [ref=f7e8]:
+        - generic [ref=f7e9]:
+          - generic [ref=f7e11]:
+            - generic:
+              - combobox [ref=f7e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f7e16]:
+                - searchbox "キーワードを入力" [ref=f7e17]
+                - button [ref=f7e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f7e20]:
+          - generic [ref=f7e22]:
+            - link " 新規会員登録" [ref=f7e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f7e25]: 
+              - generic [ref=f7e26]: 新規会員登録
+            - link " お気に入り" [ref=f7e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f7e29]: 
+              - generic [ref=f7e30]: お気に入り
+            - link " ログイン" [ref=f7e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f7e33]: 
+              - generic [ref=f7e34]: ログイン
+          - generic [ref=f7e37] [cursor=pointer]:
+            - generic [ref=f7e38]:
+              - text: 
+              - generic [ref=f7e39]: "1"
+            - generic [ref=f7e41]: ￥3,080
+      - heading "EC-CUBE SHOP" [level=1] [ref=f7e46]:
+        - link "EC-CUBE SHOP" [ref=f7e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f7e50]:
+        - listitem [ref=f7e51]:
+          - link "新入荷" [ref=f7e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f7e53]:
+          - link "ジェラート" [ref=f7e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f7e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f7e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f7e57]:
+          - link "アイスサンド" [ref=f7e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f7e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f7e61]:
+      - heading "クーポンコードの入力" [level=1] [ref=f7e64]
+      - generic [ref=f7e67]:
+        - generic [ref=f7e69]: 利用するクーポンコードを入力してください。
+        - generic [ref=f7e70]:
+          - generic [ref=f7e71]:
+            - generic [ref=f7e72]:
+              - term [ref=f7e73]
+              - definition [ref=f7e74]:
+                - generic [ref=f7e75]:
+                  - generic [ref=f7e76]:
+                    - radio "クーポンを利用しない" [checked] [active] [ref=f7e77]
+                    - generic [ref=f7e78]: クーポンを利用しない
+                  - generic [ref=f7e79]:
+                    - radio "クーポンを利用する" [ref=f7e80]
+                    - generic [ref=f7e81]: クーポンを利用する
+            - generic [ref=f7e82]:
+              - term [ref=f7e83]:
+                - generic [ref=f7e84]: クーポンコード
+              - definition [ref=f7e85]:
+                - textbox "クーポンコード" [ref=f7e86]
+          - generic [ref=f7e89]:
+            - button "登録する" [ref=f7e90] [cursor=pointer]
+            - link "戻る" [ref=f7e91] [cursor=pointer]:
+              - /url: http://localhost:8080/shopping
+    - contentinfo [ref=f7e92]:
+      - generic [ref=f7e94]:
+        - list [ref=f7e95]:
+          - listitem [ref=f7e96]:
+            - link "当サイトについて" [ref=f7e97] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f7e98]:
+            - link "プライバシーポリシー" [ref=f7e99] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f7e100]:
+            - link "特定商取引法に基づく表記" [ref=f7e101] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f7e102]:
+            - link "お問い合わせ" [ref=f7e103] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f7e104]:
+          - link "EC-CUBE SHOP" [ref=f7e106] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f7e107]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f7e108]:
+    - generic [ref=f7e111]:
+      - link "200 @ plugin_coupon_shopping" [ref=f7e113] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=request
+        - generic [ref=f7e114]:
+          - generic [ref=f7e115]: "200"
+          - generic [ref=f7e116]: "@"
+          - generic [ref=f7e117]: plugin_coupon_shopping
+      - link "170 ms" [ref=f7e119] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=time
+        - generic [ref=f7e120]:
+          - generic [ref=f7e121]: "170"
+          - generic [ref=f7e122]: ms
+      - link "12.0 MiB" [ref=f7e124] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=time
+        - generic [ref=f7e125]:
+          - generic [ref=f7e126]: "12.0"
+          - generic [ref=f7e127]: MiB
+      - link "Cache 2" [ref=f7e129] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=form
+        - generic [ref=f7e130]:
+          - img "Cache" [ref=f7e131]
+          - generic [ref=f7e137]: "2"
+      - link "Logger 24" [ref=f7e139] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=logger
+        - generic [ref=f7e140]:
+          - img "Logger" [ref=f7e141]
+          - generic [ref=f7e145]: "24"
+      - link "Cache 20 in 0.30 ms" [ref=f7e147] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=cache
+        - generic [ref=f7e148]:
+          - img "Cache" [ref=f7e149]
+          - generic [ref=f7e154]: "20"
+          - generic [ref=f7e155]: in 0.30 ms
+      - link "27" [ref=f7e157] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=translation
+        - generic [ref=f7e158]:
+          - img [ref=f7e159]
+          - generic [ref=f7e164]: "27"
+      - link "Security n/a" [ref=f7e166] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=security
+        - generic [ref=f7e167]:
+          - img "Security" [ref=f7e168]
+          - generic [ref=f7e172]: n/a
+      - link "Twig 57 ms" [ref=f7e174] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=twig
+        - generic [ref=f7e175]:
+          - img "Twig" [ref=f7e176]
+          - generic [ref=f7e180]: "57"
+          - generic [ref=f7e181]: ms
+      - link "21 in 3.94 ms" [ref=f7e183] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=db
+        - generic [ref=f7e184]:
+          - img [ref=f7e185]
+          - generic [ref=f7e190]: "21"
+          - generic [ref=f7e191]: in 3.94 ms
+      - link "22" [ref=f7e193] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=doctrine_migrations
+        - generic [ref=f7e194]:
+          - img [ref=f7e195]
+          - generic [ref=f7e198]: "22"
+      - link "Symfony 7.4.13" [ref=f7e200] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/282976?panel=config
+        - generic [ref=f7e201]:
+          - img "Symfony" [ref=f7e203]
+          - generic [ref=f7e205]: 7.4.13
+      - generic [ref=f7e207]:
+        - img "eccube_logo_basic" [ref=f7e208]
+        - generic [ref=f7e213]: 4.3.1-p1
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f7e214] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f7e215]:
+          - img [ref=f7e216]

--- a/.playwright-mcp/page-2026-07-03T07-21-49-407Z.yml
+++ b/.playwright-mcp/page-2026-07-03T07-21-49-407Z.yml
@@ -1,0 +1,147 @@
+- generic [active] [ref=e1]:
+  - banner [ref=e2]:
+    - generic [ref=e3]:
+      - heading "Symfony Exception" [level=1] [ref=e4]:
+        - img [ref=e5]
+        - text: Symfony Exception
+      - link "Symfony Docs" [ref=e8] [cursor=pointer]:
+        - /url: https://symfony.com/doc/7.4.13/index.html
+        - img [ref=e10]
+        - text: Symfony Docs
+  - generic [ref=e12]:
+    - generic [ref=e14]:
+      - heading "IOException" [level=2] [ref=e15]:
+        - link "IOException" [ref=e16] [cursor=pointer]:
+          - /url: "#trace-box-1"
+      - heading "HTTP 500 Internal Server Error" [level=2] [ref=e17]
+    - generic [ref=e19]:
+      - 'heading "Failed to remove file \"/var/www/html/var/cache/dev/.!!8kl/URI/4.19.0,81373184c6f30942fadaf90d195b52503f5834e7,1.ser\": unlink(/var/www/html/var/cache/dev/.!!8kl/URI/4.19.0,81373184c6f30942fadaf90d195b52503f5834e7,1.ser): Permission denied" [level=1] [ref=e20]'
+      - img [ref=e22]
+  - generic [ref=e25]:
+    - tablist [ref=e26]:
+      - tab "Exception" [selected] [ref=e27] [cursor=pointer]
+      - tab "Stack Trace" [ref=e28] [cursor=pointer]
+    - tabpanel [ref=e29]:
+      - generic [ref=e32]:
+        - generic [ref=e33]:
+          - generic [ref=e34] [cursor=pointer]:
+            - img [ref=e36]
+            - heading "Symfony\\Component\\Filesystem\\Exception\\ IOException" [level=3] [ref=e38]:
+              - generic [ref=e39]: Symfony\Component\Filesystem\Exception\
+              - text: IOException
+          - group [ref=e40]:
+            - generic "Show exception properties" [ref=e41] [cursor=pointer]
+        - generic [ref=e42]:
+          - generic [ref=e44] [cursor=pointer]:
+            - img [ref=e46]
+            - generic [ref=e48]:
+              - text: in
+              - link "/var/www/html/vendor/symfony/filesystem/Filesystem.php" [ref=e49]:
+                - /url: file:///var/www/html/vendor/symfony/filesystem/Filesystem.php#L197
+                - text: /var/www/html/vendor/symfony/filesystem/
+                - strong [ref=e50]: Filesystem.php
+              - text: (line 197)
+          - generic [ref=e52] [cursor=pointer]:
+            - img [ref=e54]
+            - generic [ref=e56]:
+              - text: in
+              - link "/var/www/html/vendor/symfony/filesystem/Filesystem.php" [ref=e57]:
+                - /url: file:///var/www/html/vendor/symfony/filesystem/Filesystem.php#L185
+                - text: /var/www/html/vendor/symfony/filesystem/
+                - strong [ref=e58]: Filesystem.php
+              - text: ":: doRemove (line 185)"
+          - generic [ref=e60] [cursor=pointer]:
+            - img [ref=e62]
+            - generic [ref=e64]:
+              - text: in
+              - link "/var/www/html/vendor/symfony/filesystem/Filesystem.php" [ref=e65]:
+                - /url: file:///var/www/html/vendor/symfony/filesystem/Filesystem.php#L185
+                - text: /var/www/html/vendor/symfony/filesystem/
+                - strong [ref=e66]: Filesystem.php
+              - text: ":: doRemove (line 185)"
+          - generic [ref=e68] [cursor=pointer]:
+            - img [ref=e70]
+            - generic [ref=e72]:
+              - text: in
+              - link "/var/www/html/vendor/symfony/filesystem/Filesystem.php" [ref=e73]:
+                - /url: file:///var/www/html/vendor/symfony/filesystem/Filesystem.php#L153
+                - text: /var/www/html/vendor/symfony/filesystem/
+                - strong [ref=e74]: Filesystem.php
+              - text: ":: doRemove (line 153)"
+          - generic [ref=e76] [cursor=pointer]:
+            - img [ref=e78]
+            - generic [ref=e80]:
+              - text: in
+              - link "/var/www/html/vendor/exercise/htmlpurifier-bundle/src/CacheWarmer/SerializerCacheWarmer.php" [ref=e81]:
+                - /url: file:///var/www/html/vendor/exercise/htmlpurifier-bundle/src/CacheWarmer/SerializerCacheWarmer.php#L43
+                - text: /var/www/html/vendor/exercise/htmlpurifier-bundle/src/CacheWarmer/
+                - strong [ref=e82]: SerializerCacheWarmer.php
+              - text: "-> remove (line 43)"
+          - generic [ref=e84] [cursor=pointer]:
+            - img [ref=e86]
+            - generic [ref=e88]:
+              - text: in
+              - link "/var/www/html/vendor/symfony/http-kernel/CacheWarmer/CacheWarmerAggregate.php" [ref=e89]:
+                - /url: file:///var/www/html/vendor/symfony/http-kernel/CacheWarmer/CacheWarmerAggregate.php#L96
+                - text: /var/www/html/vendor/symfony/http-kernel/CacheWarmer/
+                - strong [ref=e90]: CacheWarmerAggregate.php
+              - text: "-> warmUp (line 96)"
+          - generic [ref=e92] [cursor=pointer]:
+            - img [ref=e94]
+            - generic [ref=e96]:
+              - text: in
+              - link "/var/www/html/vendor/symfony/http-kernel/Kernel.php" [ref=e97]:
+                - /url: file:///var/www/html/vendor/symfony/http-kernel/Kernel.php#L563
+                - text: /var/www/html/vendor/symfony/http-kernel/
+                - strong [ref=e98]: Kernel.php
+              - text: "-> warmUp (line 563)"
+          - generic [ref=e100] [cursor=pointer]:
+            - img [ref=e102]
+            - generic [ref=e104]:
+              - text: in
+              - link "/var/www/html/vendor/symfony/http-kernel/Kernel.php" [ref=e105]:
+                - /url: file:///var/www/html/vendor/symfony/http-kernel/Kernel.php#L762
+                - text: /var/www/html/vendor/symfony/http-kernel/
+                - strong [ref=e106]: Kernel.php
+              - text: "-> initializeContainer (line 762)"
+          - generic [ref=e108] [cursor=pointer]:
+            - img [ref=e110]
+            - generic [ref=e112]:
+              - text: in
+              - link "/var/www/html/vendor/symfony/http-kernel/Kernel.php" [ref=e113]:
+                - /url: file:///var/www/html/vendor/symfony/http-kernel/Kernel.php#L172
+                - text: /var/www/html/vendor/symfony/http-kernel/
+                - strong [ref=e114]: Kernel.php
+              - text: "-> preBoot (line 172)"
+          - generic [ref=e115]:
+            - generic [ref=e116] [cursor=pointer]:
+              - img [ref=e118]
+              - generic [ref=e120]: Kernel
+              - text: "->handle()"
+              - generic [ref=e121]:
+                - text: in
+                - link "/var/www/html/index.php" [ref=e122]:
+                  - /url: file:///var/www/html/index.php#L100
+                  - text: /var/www/html/
+                  - strong [ref=e123]: index.php
+                - text: (line 100)
+                - img [ref=e125]
+            - list [ref=e129]:
+              - listitem [ref=e130]:
+                - code [ref=e131]: "}"
+              - listitem [ref=e132]:
+                - code [ref=e133]: "}"
+              - listitem [ref=e134]:
+                - code [ref=e135]: "}"
+              - listitem [ref=e136]:
+                - code
+              - listitem [ref=e137]:
+                - code [ref=e138]: $kernel = new Kernel($env, $debug);
+              - listitem [ref=e139]:
+                - code [ref=e140]: $response = $kernel->handle($request);
+              - listitem [ref=e141]:
+                - code [ref=e142]: $response->send();
+              - listitem [ref=e143]:
+                - code [ref=e144]: $kernel->terminate($request, $response);
+              - listitem [ref=e145]:
+                - code

--- a/.playwright-mcp/page-2026-07-03T07-23-01-508Z.yml
+++ b/.playwright-mcp/page-2026-07-03T07-23-01-508Z.yml
@@ -1,0 +1,132 @@
+- generic [active] [ref=f1e1]:
+  - generic [ref=f1e3]:
+    - img [ref=f1e5]
+    - text: デバッグモードが有効になっています。
+  - generic [ref=f1e6]:
+    - banner [ref=f1e7]:
+      - generic [ref=f1e8]:
+        - generic [ref=f1e9]:
+          - generic [ref=f1e11]:
+            - generic:
+              - combobox [ref=f1e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f1e16]:
+                - searchbox "キーワードを入力" [ref=f1e17]
+                - button [ref=f1e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f1e20]:
+          - generic [ref=f1e22]:
+            - link " 新規会員登録" [ref=f1e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f1e25]: 
+              - generic [ref=f1e26]: 新規会員登録
+            - link " お気に入り" [ref=f1e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f1e29]: 
+              - generic [ref=f1e30]: お気に入り
+            - link " ログイン" [ref=f1e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f1e33]: 
+              - generic [ref=f1e34]: ログイン
+          - generic [ref=f1e37] [cursor=pointer]:
+            - generic [ref=f1e38]:
+              - text: 
+              - generic [ref=f1e39]: "0"
+            - generic [ref=f1e41]: ￥0
+      - heading "EC-CUBE SHOP" [level=1] [ref=f1e46]:
+        - link "EC-CUBE SHOP" [ref=f1e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f1e50]:
+        - listitem [ref=f1e51]:
+          - link "新入荷" [ref=f1e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f1e53]:
+          - link "ジェラート" [ref=f1e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f1e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f1e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f1e57]:
+          - link "アイスサンド" [ref=f1e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f1e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f1e61]:
+      - generic [ref=f1e63]:
+        - generic [ref=f1e68]:
+          - img "チェリーアイスサンド" [ref=f1e75]
+          - img [ref=f1e85]
+        - generic [ref=f1e97]:
+          - heading "チェリーアイスサンド" [level=2] [ref=f1e99]
+          - list [ref=f1e100]
+          - text: 通常価格：￥3,300 税込
+          - generic [ref=f1e102]:
+            - generic [ref=f1e103]: ￥3,080
+            - text: 税込
+          - generic [ref=f1e104]: 商品コード： sand-01
+          - generic [ref=f1e105]:
+            - generic [ref=f1e106]: 関連カテゴリ
+            - list [ref=f1e107]:
+              - listitem [ref=f1e108]:
+                - link "新入荷" [ref=f1e109] [cursor=pointer]:
+                  - /url: http://localhost:8080/products/list?category_id=2
+              - listitem [ref=f1e110]:
+                - link "アイスサンド" [ref=f1e111] [cursor=pointer]:
+                  - /url: http://localhost:8080/products/list?category_id=5
+                - text: ">"
+                - link "フルーツ" [ref=f1e112] [cursor=pointer]:
+                  - /url: http://localhost:8080/products/list?category_id=6
+          - generic [ref=f1e113]:
+            - generic [ref=f1e115]:
+              - text: 数量
+              - spinbutton [ref=f1e116]: "1"
+            - button "カートに入れる" [ref=f1e118] [cursor=pointer]
+          - button "お気に入りに追加" [ref=f1e121] [cursor=pointer]
+          - generic [ref=f1e122]:
+            - text: チェリーアイスサンドは北海道産のチェリーのアイスをサクサクのクッキーでサンドしたスイーツです。
+            - text: 立方体なので大量に持ち運ぶときも便利です。
+            - text: いまだけ、頑丈な箱つきです。
+    - contentinfo [ref=f1e123]:
+      - generic [ref=f1e125]:
+        - list [ref=f1e126]:
+          - listitem [ref=f1e127]:
+            - link "当サイトについて" [ref=f1e128] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f1e129]:
+            - link "プライバシーポリシー" [ref=f1e130] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f1e131]:
+            - link "特定商取引法に基づく表記" [ref=f1e132] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f1e133]:
+            - link "お問い合わせ" [ref=f1e134] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f1e135]:
+          - link "EC-CUBE SHOP" [ref=f1e137] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f1e138]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f1e139]:
+    - generic [ref=f1e142]:
+      - link "Symfony Loading…" [ref=f1e144] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/4a927b?panel=request
+        - generic [ref=f1e145]:
+          - img "Symfony" [ref=f1e146]
+          - generic [ref=f1e148]: Loading…
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f1e149] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f1e150]:
+          - img [ref=f1e151]

--- a/.playwright-mcp/page-2026-07-03T07-23-31-914Z.yml
+++ b/.playwright-mcp/page-2026-07-03T07-23-31-914Z.yml
@@ -1,0 +1,155 @@
+- generic [active] [ref=f2e1]:
+  - generic [ref=f2e3]:
+    - img [ref=f2e5]
+    - text: デバッグモードが有効になっています。
+  - generic [ref=f2e6]:
+    - banner [ref=f2e7]:
+      - generic [ref=f2e8]:
+        - generic [ref=f2e9]:
+          - generic [ref=f2e11]:
+            - generic:
+              - combobox [ref=f2e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f2e16]:
+                - searchbox "キーワードを入力" [ref=f2e17]
+                - button [ref=f2e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f2e20]:
+          - generic [ref=f2e22]:
+            - link " 新規会員登録" [ref=f2e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f2e25]: 
+              - generic [ref=f2e26]: 新規会員登録
+            - link " お気に入り" [ref=f2e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f2e29]: 
+              - generic [ref=f2e30]: お気に入り
+            - link " ログイン" [ref=f2e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f2e33]: 
+              - generic [ref=f2e34]: ログイン
+          - generic [ref=f2e37] [cursor=pointer]:
+            - generic [ref=f2e38]:
+              - text: 
+              - generic [ref=f2e39]: "1"
+            - generic [ref=f2e41]: ￥3,080
+      - heading "EC-CUBE SHOP" [level=1] [ref=f2e46]:
+        - link "EC-CUBE SHOP" [ref=f2e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f2e50]:
+        - listitem [ref=f2e51]:
+          - link "新入荷" [ref=f2e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f2e53]:
+          - link "ジェラート" [ref=f2e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f2e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f2e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f2e57]:
+          - link "アイスサンド" [ref=f2e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f2e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f2e61]:
+      - heading "ショッピングカート" [level=1] [ref=f2e64]
+      - generic [ref=f2e65]:
+        - list [ref=f2e67]:
+          - listitem [ref=f2e68]:
+            - generic [ref=f2e69]: "1"
+            - generic [ref=f2e70]: カートの商品
+          - listitem [ref=f2e71]:
+            - generic [ref=f2e72]: "2"
+            - generic [ref=f2e73]: お客様情報
+          - listitem [ref=f2e74]:
+            - generic [ref=f2e75]: "3"
+            - generic [ref=f2e76]: ご注文手続き
+          - listitem [ref=f2e77]:
+            - generic [ref=f2e78]: "4"
+            - generic [ref=f2e79]: ご注文内容確認
+          - listitem [ref=f2e80]:
+            - generic [ref=f2e81]: "5"
+            - generic [ref=f2e82]: 完了
+        - paragraph [ref=f2e84]:
+          - text: 商品の合計金額は「
+          - strong [ref=f2e85]: ￥3,080
+          - text: 」です。
+        - generic [ref=f2e86]:
+          - generic [ref=f2e88]:
+            - list [ref=f2e89]:
+              - listitem [ref=f2e90]: 削除
+              - listitem [ref=f2e91]: 商品内容
+              - listitem [ref=f2e92]: 数量
+              - listitem [ref=f2e93]: 小計
+            - list [ref=f2e94]:
+              - listitem [ref=f2e95]:
+                - link "delete" [ref=f2e96] [cursor=pointer]:
+                  - /url: http://localhost:8080/cart/remove/11
+                  - img "delete" [ref=f2e97]
+              - listitem [ref=f2e98]:
+                - link "チェリーアイスサンド" [ref=f2e100] [cursor=pointer]:
+                  - /url: http://localhost:8080/products/detail/2
+                  - img "チェリーアイスサンド" [ref=f2e101]
+                - generic [ref=f2e102]:
+                  - link "チェリーアイスサンド" [ref=f2e104] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/detail/2
+                  - generic [ref=f2e105]: ￥3,080
+              - listitem [ref=f2e106]:
+                - generic [ref=f2e107]: "1"
+                - generic [ref=f2e108]:
+                  - img "reduce" [ref=f2e110]
+                  - link "increase" [ref=f2e111] [cursor=pointer]:
+                    - /url: http://localhost:8080/cart/up/11
+                    - img "increase" [ref=f2e112]
+              - listitem [ref=f2e113]:
+                - generic [ref=f2e114]: ￥3,080
+          - generic [ref=f2e115]:
+            - generic [ref=f2e116]: 合計：￥3,080
+            - link "レジに進む" [ref=f2e117] [cursor=pointer]:
+              - /url: /cart/buystep/y2SO9nEkZCKuqIkuKxFlmMHvTXo1Jdv4_1
+            - link "お買い物を続ける" [ref=f2e118] [cursor=pointer]:
+              - /url: /
+    - contentinfo [ref=f2e119]:
+      - generic [ref=f2e121]:
+        - list [ref=f2e122]:
+          - listitem [ref=f2e123]:
+            - link "当サイトについて" [ref=f2e124] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f2e125]:
+            - link "プライバシーポリシー" [ref=f2e126] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f2e127]:
+            - link "特定商取引法に基づく表記" [ref=f2e128] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f2e129]:
+            - link "お問い合わせ" [ref=f2e130] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f2e131]:
+          - link "EC-CUBE SHOP" [ref=f2e133] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f2e134]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f2e135]:
+    - generic [ref=f2e138]:
+      - link "Symfony Loading…" [ref=f2e140] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/438632?panel=request
+        - generic [ref=f2e141]:
+          - img "Symfony" [ref=f2e142]
+          - generic [ref=f2e144]: Loading…
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f2e145] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f2e146]:
+          - img [ref=f2e147]

--- a/.playwright-mcp/page-2026-07-03T07-23-47-382Z.yml
+++ b/.playwright-mcp/page-2026-07-03T07-23-47-382Z.yml
@@ -1,0 +1,182 @@
+- generic [ref=f3e1]:
+  - generic [ref=f3e3]:
+    - img [ref=f3e5]
+    - text: デバッグモードが有効になっています。
+  - generic [ref=f3e6]:
+    - banner [ref=f3e7]:
+      - generic [ref=f3e8]:
+        - generic [ref=f3e9]:
+          - generic [ref=f3e11]:
+            - generic:
+              - combobox [ref=f3e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f3e16]:
+                - searchbox "キーワードを入力" [ref=f3e17]
+                - button [ref=f3e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f3e20]:
+          - generic [ref=f3e22]:
+            - link " 新規会員登録" [ref=f3e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f3e25]: 
+              - generic [ref=f3e26]: 新規会員登録
+            - link " お気に入り" [ref=f3e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f3e29]: 
+              - generic [ref=f3e30]: お気に入り
+            - link " ログイン" [ref=f3e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f3e33]: 
+              - generic [ref=f3e34]: ログイン
+          - generic [ref=f3e37] [cursor=pointer]:
+            - generic [ref=f3e38]:
+              - text: 
+              - generic [ref=f3e39]: "1"
+            - generic [ref=f3e41]: ￥3,080
+      - heading "EC-CUBE SHOP" [level=1] [ref=f3e46]:
+        - link "EC-CUBE SHOP" [ref=f3e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f3e50]:
+        - listitem [ref=f3e51]:
+          - link "新入荷" [ref=f3e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f3e53]:
+          - link "ジェラート" [ref=f3e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f3e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f3e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f3e57]:
+          - link "アイスサンド" [ref=f3e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f3e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f3e61]:
+      - heading "ログイン" [level=1] [ref=f3e64]
+      - generic [ref=f3e66]:
+        - generic [ref=f3e69]:
+          - generic [ref=f3e72]:
+            - generic [ref=f3e73]:
+              - textbox "メールアドレス" [active] [ref=f3e74]
+              - textbox "パスワード" [ref=f3e75]
+            - generic [ref=f3e78]:
+              - checkbox "次回から自動的にログインする" [ref=f3e79]
+              - generic [ref=f3e80]: 次回から自動的にログインする
+          - generic [ref=f3e81]:
+            - button "ログイン" [ref=f3e84] [cursor=pointer]
+            - generic [ref=f3e85]:
+              - link "ログイン情報をお忘れですか？" [ref=f3e87] [cursor=pointer]:
+                - /url: http://localhost:8080/forgot
+              - link "新規会員登録" [ref=f3e89] [cursor=pointer]:
+                - /url: http://localhost:8080/entry
+        - generic [ref=f3e92]:
+          - paragraph [ref=f3e93]: 会員登録をせずに購入手続きをされたい方は、下記よりお進みください。
+          - link "ゲスト購入" [ref=f3e95] [cursor=pointer]:
+            - /url: http://localhost:8080/shopping/nonmember
+    - contentinfo [ref=f3e96]:
+      - generic [ref=f3e98]:
+        - list [ref=f3e99]:
+          - listitem [ref=f3e100]:
+            - link "当サイトについて" [ref=f3e101] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f3e102]:
+            - link "プライバシーポリシー" [ref=f3e103] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f3e104]:
+            - link "特定商取引法に基づく表記" [ref=f3e105] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f3e106]:
+            - link "お問い合わせ" [ref=f3e107] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f3e108]:
+          - link "EC-CUBE SHOP" [ref=f3e110] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f3e111]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f3e112]:
+    - generic [ref=f3e115]:
+      - link "200 Redirect @ shopping_login" [ref=f3e117] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/90d0f1?panel=request
+        - generic [ref=f3e118]:
+          - generic [ref=f3e119]: "200"
+          - img "Redirect" [ref=f3e121]
+          - generic [ref=f3e124]: "@"
+          - generic [ref=f3e125]: shopping_login
+      - link "169 ms" [ref=f3e127] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/90d0f1?panel=time
+        - generic [ref=f3e128]:
+          - generic [ref=f3e129]: "169"
+          - generic [ref=f3e130]: ms
+      - link "12.0 MiB" [ref=f3e132] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/90d0f1?panel=time
+        - generic [ref=f3e133]:
+          - generic [ref=f3e134]: "12.0"
+          - generic [ref=f3e135]: MiB
+      - link "Cache 1" [ref=f3e137] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/90d0f1?panel=form
+        - generic [ref=f3e138]:
+          - img "Cache" [ref=f3e139]
+          - generic [ref=f3e145]: "1"
+      - link "Logger 11" [ref=f3e147] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/90d0f1?panel=logger
+        - generic [ref=f3e148]:
+          - img "Logger" [ref=f3e149]
+          - generic [ref=f3e153]: "11"
+      - link "Cache 20 in 0.34 ms" [ref=f3e155] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/90d0f1?panel=cache
+        - generic [ref=f3e156]:
+          - img "Cache" [ref=f3e157]
+          - generic [ref=f3e162]: "20"
+          - generic [ref=f3e163]: in 0.34 ms
+      - link "3" [ref=f3e165] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/90d0f1?panel=translation
+        - generic [ref=f3e166]:
+          - img [ref=f3e167]
+          - generic [ref=f3e172]: "3"
+      - link "Security n/a" [ref=f3e174] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/90d0f1?panel=security
+        - generic [ref=f3e175]:
+          - img "Security" [ref=f3e176]
+          - generic [ref=f3e180]: n/a
+      - link "Twig 67 ms" [ref=f3e182] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/90d0f1?panel=twig
+        - generic [ref=f3e183]:
+          - img "Twig" [ref=f3e184]
+          - generic [ref=f3e188]: "67"
+          - generic [ref=f3e189]: ms
+      - link "19 in 5.40 ms" [ref=f3e191] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/90d0f1?panel=db
+        - generic [ref=f3e192]:
+          - img [ref=f3e193]
+          - generic [ref=f3e198]: "19"
+          - generic [ref=f3e199]: in 5.40 ms
+      - link "22" [ref=f3e201] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/90d0f1?panel=doctrine_migrations
+        - generic [ref=f3e202]:
+          - img [ref=f3e203]
+          - generic [ref=f3e206]: "22"
+      - link "Symfony 7.4.13" [ref=f3e208] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/90d0f1?panel=config
+        - generic [ref=f3e209]:
+          - img "Symfony" [ref=f3e211]
+          - generic [ref=f3e213]: 7.4.13
+      - generic [ref=f3e215]:
+        - img "eccube_logo_basic" [ref=f3e216]
+        - generic [ref=f3e221]: 4.3.1-p1
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f3e222] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f3e223]:
+          - img [ref=f3e224]

--- a/.playwright-mcp/page-2026-07-03T07-23-52-543Z.yml
+++ b/.playwright-mcp/page-2026-07-03T07-23-52-543Z.yml
@@ -1,0 +1,219 @@
+- generic [active] [ref=f4e1]:
+  - generic [ref=f4e3]:
+    - img [ref=f4e5]
+    - text: デバッグモードが有効になっています。
+  - generic [ref=f4e6]:
+    - banner [ref=f4e7]:
+      - generic [ref=f4e8]:
+        - generic [ref=f4e9]:
+          - generic [ref=f4e11]:
+            - generic:
+              - combobox [ref=f4e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f4e16]:
+                - searchbox "キーワードを入力" [ref=f4e17]
+                - button [ref=f4e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f4e20]:
+          - generic [ref=f4e22]:
+            - link " 新規会員登録" [ref=f4e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f4e25]: 
+              - generic [ref=f4e26]: 新規会員登録
+            - link " お気に入り" [ref=f4e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f4e29]: 
+              - generic [ref=f4e30]: お気に入り
+            - link " ログイン" [ref=f4e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f4e33]: 
+              - generic [ref=f4e34]: ログイン
+          - generic [ref=f4e37] [cursor=pointer]:
+            - generic [ref=f4e38]:
+              - text: 
+              - generic [ref=f4e39]: "1"
+            - generic [ref=f4e41]: ￥3,080
+      - heading "EC-CUBE SHOP" [level=1] [ref=f4e46]:
+        - link "EC-CUBE SHOP" [ref=f4e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f4e50]:
+        - listitem [ref=f4e51]:
+          - link "新入荷" [ref=f4e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f4e53]:
+          - link "ジェラート" [ref=f4e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f4e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f4e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f4e57]:
+          - link "アイスサンド" [ref=f4e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f4e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f4e61]:
+      - generic [ref=f4e62]:
+        - heading "お客様情報の入力" [level=1] [ref=f4e64]
+        - list [ref=f4e67]:
+          - listitem [ref=f4e68]:
+            - generic [ref=f4e69]: "1"
+            - generic [ref=f4e70]: カートの商品
+          - listitem [ref=f4e71]:
+            - generic [ref=f4e72]: "2"
+            - generic [ref=f4e73]: お客様情報
+          - listitem [ref=f4e74]:
+            - generic [ref=f4e75]: "3"
+            - generic [ref=f4e76]: ご注文手続き
+          - listitem [ref=f4e77]:
+            - generic [ref=f4e78]: "4"
+            - generic [ref=f4e79]: ご注文内容確認
+          - listitem [ref=f4e80]:
+            - generic [ref=f4e81]: "5"
+            - generic [ref=f4e82]: 完了
+        - generic [ref=f4e85]:
+          - generic [ref=f4e86]:
+            - generic [ref=f4e87]:
+              - term [ref=f4e88]:
+                - generic [ref=f4e89]: お名前
+                - generic [ref=f4e90]: 必須
+              - definition [ref=f4e91]:
+                - generic [ref=f4e92]:
+                  - textbox "姓" [ref=f4e93]
+                  - textbox "名" [ref=f4e94]
+            - generic [ref=f4e95]:
+              - term [ref=f4e96]:
+                - generic [ref=f4e97]: お名前(カナ)
+                - generic [ref=f4e98]: 必須
+              - definition [ref=f4e99]:
+                - generic [ref=f4e100]:
+                  - textbox "セイ" [ref=f4e101]
+                  - textbox "メイ" [ref=f4e102]
+            - generic [ref=f4e103]:
+              - term [ref=f4e104]:
+                - generic [ref=f4e105]: 会社名
+              - definition [ref=f4e106]:
+                - textbox "会社名" [ref=f4e108]
+            - generic [ref=f4e109]:
+              - term [ref=f4e110]:
+                - generic [ref=f4e111]: 住所
+                - generic [ref=f4e112]: 必須
+              - definition [ref=f4e113]:
+                - generic [ref=f4e114]:
+                  - generic [ref=f4e115]: 〒
+                  - textbox "例：5300001" [ref=f4e116]
+                  - link "郵便番号検索" [ref=f4e120] [cursor=pointer]:
+                    - /url: https://www.post.japanpost.jp/zipcode/
+                    - generic: 郵便番号検索
+                - combobox [ref=f4e122]:
+                  - option "都道府県を選択" [selected]
+                  - option "北海道"
+                  - option "青森県"
+                  - option "岩手県"
+                  - option "宮城県"
+                  - option "秋田県"
+                  - option "山形県"
+                  - option "福島県"
+                  - option "茨城県"
+                  - option "栃木県"
+                  - option "群馬県"
+                  - option "埼玉県"
+                  - option "千葉県"
+                  - option "東京都"
+                  - option "神奈川県"
+                  - option "新潟県"
+                  - option "富山県"
+                  - option "石川県"
+                  - option "福井県"
+                  - option "山梨県"
+                  - option "長野県"
+                  - option "岐阜県"
+                  - option "静岡県"
+                  - option "愛知県"
+                  - option "三重県"
+                  - option "滋賀県"
+                  - option "京都府"
+                  - option "大阪府"
+                  - option "兵庫県"
+                  - option "奈良県"
+                  - option "和歌山県"
+                  - option "鳥取県"
+                  - option "島根県"
+                  - option "岡山県"
+                  - option "広島県"
+                  - option "山口県"
+                  - option "徳島県"
+                  - option "香川県"
+                  - option "愛媛県"
+                  - option "高知県"
+                  - option "福岡県"
+                  - option "佐賀県"
+                  - option "長崎県"
+                  - option "熊本県"
+                  - option "大分県"
+                  - option "宮崎県"
+                  - option "鹿児島県"
+                  - option "沖縄県"
+                - textbox "市区町村名(例：大阪市北区)" [ref=f4e124]
+                - textbox "番地・ビル名(例：西梅田1丁目6-8)" [ref=f4e126]
+            - generic [ref=f4e127]:
+              - term [ref=f4e128]:
+                - generic [ref=f4e129]: 電話番号
+                - generic [ref=f4e130]: 必須
+              - definition [ref=f4e131]:
+                - textbox "電話番号" [ref=f4e133]:
+                  - /placeholder: 例：11122223333
+            - generic [ref=f4e134]:
+              - term [ref=f4e135]:
+                - generic [ref=f4e136]: メールアドレス
+                - generic [ref=f4e137]: 必須
+              - definition [ref=f4e138]:
+                - textbox "例：ec-cube@example.com" [ref=f4e140]
+                - textbox "確認のためもう一度入力してください" [ref=f4e142]
+          - generic [ref=f4e145]:
+            - button "次へ" [ref=f4e146] [cursor=pointer]
+            - link "戻る" [ref=f4e147] [cursor=pointer]:
+              - /url: http://localhost:8080/cart
+    - contentinfo [ref=f4e148]:
+      - generic [ref=f4e150]:
+        - list [ref=f4e151]:
+          - listitem [ref=f4e152]:
+            - link "当サイトについて" [ref=f4e153] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f4e154]:
+            - link "プライバシーポリシー" [ref=f4e155] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f4e156]:
+            - link "特定商取引法に基づく表記" [ref=f4e157] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f4e158]:
+            - link "お問い合わせ" [ref=f4e159] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f4e160]:
+          - link "EC-CUBE SHOP" [ref=f4e162] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f4e163]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f4e164]:
+    - generic [ref=f4e167]:
+      - link "Symfony Loading…" [ref=f4e169] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/31cd20?panel=request
+        - generic [ref=f4e170]:
+          - img "Symfony" [ref=f4e171]
+          - generic [ref=f4e173]: Loading…
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f4e174] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f4e175]:
+          - img [ref=f4e176]

--- a/.playwright-mcp/page-2026-07-03T07-24-15-863Z.yml
+++ b/.playwright-mcp/page-2026-07-03T07-24-15-863Z.yml
@@ -1,0 +1,271 @@
+- generic [active] [ref=f5e1]:
+  - generic [ref=f5e3]:
+    - img [ref=f5e5]
+    - text: デバッグモードが有効になっています。
+  - generic [ref=f5e6]:
+    - banner [ref=f5e7]:
+      - generic [ref=f5e8]:
+        - generic [ref=f5e9]:
+          - generic [ref=f5e11]:
+            - generic:
+              - combobox [ref=f5e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f5e16]:
+                - searchbox "キーワードを入力" [ref=f5e17]
+                - button [ref=f5e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f5e20]:
+          - generic [ref=f5e22]:
+            - link " 新規会員登録" [ref=f5e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f5e25]: 
+              - generic [ref=f5e26]: 新規会員登録
+            - link " お気に入り" [ref=f5e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f5e29]: 
+              - generic [ref=f5e30]: お気に入り
+            - link " ログイン" [ref=f5e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f5e33]: 
+              - generic [ref=f5e34]: ログイン
+          - generic [ref=f5e37] [cursor=pointer]:
+            - generic [ref=f5e38]:
+              - text: 
+              - generic [ref=f5e39]: "1"
+            - generic [ref=f5e41]: ￥3,080
+      - heading "EC-CUBE SHOP" [level=1] [ref=f5e46]:
+        - link "EC-CUBE SHOP" [ref=f5e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f5e50]:
+        - listitem [ref=f5e51]:
+          - link "新入荷" [ref=f5e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f5e53]:
+          - link "ジェラート" [ref=f5e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f5e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f5e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f5e57]:
+          - link "アイスサンド" [ref=f5e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f5e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f5e61]:
+      - heading "ご注文手続き" [level=1] [ref=f5e64]
+      - list [ref=f5e67]:
+        - listitem [ref=f5e68]:
+          - generic [ref=f5e69]: "1"
+          - generic [ref=f5e70]: カートの商品
+        - listitem [ref=f5e71]:
+          - generic [ref=f5e72]: "2"
+          - generic [ref=f5e73]: お客様情報
+        - listitem [ref=f5e74]:
+          - generic [ref=f5e75]: "3"
+          - generic [ref=f5e76]: ご注文手続き
+        - listitem [ref=f5e77]:
+          - generic [ref=f5e78]: "4"
+          - generic [ref=f5e79]: ご注文内容確認
+        - listitem [ref=f5e80]:
+          - generic [ref=f5e81]: "5"
+          - generic [ref=f5e82]: 完了
+      - generic [ref=f5e84]:
+        - generic [ref=f5e85]:
+          - generic [ref=f5e86]:
+            - heading "お客様情報" [level=2] [ref=f5e88]
+            - button "変更" [ref=f5e90] [cursor=pointer]
+            - generic [ref=f5e91]:
+              - paragraph [ref=f5e92]: 山田 太郎 様
+              - paragraph [ref=f5e93]: ヤマダ タロウ
+              - paragraph
+              - paragraph [ref=f5e94]:
+                - text: 〒
+                - generic [ref=f5e95]: "1000001"
+              - paragraph [ref=f5e96]: 東京都千代田区千代田1-1
+              - paragraph [ref=f5e97]: "0300000000"
+              - paragraph [ref=f5e98]: guest@example.com
+          - generic [ref=f5e99]:
+            - heading "配送情報" [level=2] [ref=f5e101]
+            - generic [ref=f5e102]:
+              - text: お届け先
+              - button "変更" [ref=f5e104] [cursor=pointer]
+            - generic [ref=f5e105]:
+              - list [ref=f5e106]:
+                - listitem [ref=f5e107]:
+                  - generic [ref=f5e108]:
+                    - img "チェリーアイスサンド" [ref=f5e110]
+                    - generic [ref=f5e111]:
+                      - paragraph [ref=f5e112]: チェリーアイスサンド
+                      - paragraph [ref=f5e113]: ￥3,080 × 1小計：￥3,080
+              - paragraph
+            - generic [ref=f5e114]:
+              - paragraph [ref=f5e115]: 山田 太郎 (ヤマダ タロウ) 様
+              - paragraph [ref=f5e116]: 〒1000001 東京都千代田区千代田1-1
+              - paragraph [ref=f5e117]: "0300000000"
+            - generic [ref=f5e119]:
+              - generic [ref=f5e120]:
+                - generic [ref=f5e121]: 配送方法
+                - combobox [ref=f5e122]:
+                  - option "サンプル業者" [selected]
+              - generic [ref=f5e123]:
+                - generic [ref=f5e124]: お届け日
+                - combobox [ref=f5e125]:
+                  - option "指定なし" [selected]
+              - generic [ref=f5e126]:
+                - generic [ref=f5e127]: お届け時間
+                - combobox [ref=f5e128]:
+                  - option "指定なし" [selected]
+                  - option "午前"
+                  - option "午後"
+            - button "お届け先を追加する" [ref=f5e130] [cursor=pointer]
+          - generic [ref=f5e131]:
+            - heading "お支払方法" [level=2] [ref=f5e133]
+            - generic [ref=f5e134]:
+              - generic [ref=f5e135]:
+                - radio "郵便振替" [checked] [ref=f5e136]
+                - generic [ref=f5e137]: 郵便振替
+              - generic [ref=f5e138]:
+                - radio "現金書留" [ref=f5e139]
+                - generic [ref=f5e140]: 現金書留
+              - generic [ref=f5e141]:
+                - radio "銀行振込" [ref=f5e142]
+                - generic [ref=f5e143]: 銀行振込
+              - generic [ref=f5e144]:
+                - radio "代金引換" [ref=f5e145]
+                - generic [ref=f5e146]: 代金引換
+          - generic [ref=f5e147]:
+            - heading "クーポン" [level=2] [ref=f5e149]
+            - generic [ref=f5e150]:
+              - text: クーポンをお持ちの方はクーポンコードを入力してください。
+              - paragraph [ref=f5e151]:
+                - link "クーポンを変更する" [ref=f5e152] [cursor=pointer]:
+                  - /url: http://localhost:8080/plugin/coupon/shopping/shopping_coupon
+          - generic [ref=f5e153]:
+            - heading "お問い合わせ" [level=2] [ref=f5e155]
+            - textbox "お問い合わせ事項がございましたら、こちらにご入力ください。(3000文字まで)" [ref=f5e157]
+        - generic [ref=f5e159]:
+          - generic [ref=f5e160]:
+            - term [ref=f5e161]: 小計
+            - definition [ref=f5e162]: ￥3,080
+          - generic [ref=f5e163]:
+            - term [ref=f5e164]: 手数料
+            - definition [ref=f5e165]: ￥0
+          - generic [ref=f5e166]:
+            - term [ref=f5e167]: 送料
+            - definition [ref=f5e168]: ￥1,000
+          - generic [ref=f5e169]: 合計￥4,080税込
+          - generic [ref=f5e170]: お支払い合計￥4,080税込
+          - generic [ref=f5e171]:
+            - term [ref=f5e172]: "[ 税率 10 %対象"
+            - definition [ref=f5e173]: ￥4,080 (内消費税 ￥371) ]
+          - generic [ref=f5e174]:
+            - button "確認する" [ref=f5e175] [cursor=pointer]
+            - link "カートに戻る" [ref=f5e176] [cursor=pointer]:
+              - /url: http://localhost:8080/cart
+    - contentinfo [ref=f5e177]:
+      - generic [ref=f5e179]:
+        - list [ref=f5e180]:
+          - listitem [ref=f5e181]:
+            - link "当サイトについて" [ref=f5e182] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f5e183]:
+            - link "プライバシーポリシー" [ref=f5e184] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f5e185]:
+            - link "特定商取引法に基づく表記" [ref=f5e186] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f5e187]:
+            - link "お問い合わせ" [ref=f5e188] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f5e189]:
+          - link "EC-CUBE SHOP" [ref=f5e191] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f5e192]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f5e193]:
+    - generic [ref=f5e196]:
+      - link "200 Redirect @ shopping" [ref=f5e198] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a937b?panel=request
+        - generic [ref=f5e199]:
+          - generic [ref=f5e200]: "200"
+          - img "Redirect" [ref=f5e202]
+          - generic [ref=f5e205]: "@"
+          - generic [ref=f5e206]: shopping
+      - link "464 ms" [ref=f5e208] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a937b?panel=time
+        - generic [ref=f5e209]:
+          - generic [ref=f5e210]: "464"
+          - generic [ref=f5e211]: ms
+      - link "16.0 MiB" [ref=f5e213] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a937b?panel=time
+        - generic [ref=f5e214]:
+          - generic [ref=f5e215]: "16.0"
+          - generic [ref=f5e216]: MiB
+      - link "Cache 2" [ref=f5e218] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a937b?panel=form
+        - generic [ref=f5e219]:
+          - img "Cache" [ref=f5e220]
+          - generic [ref=f5e226]: "2"
+      - link "Logger 22" [ref=f5e228] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a937b?panel=logger
+        - generic [ref=f5e229]:
+          - img "Logger" [ref=f5e230]
+          - generic [ref=f5e234]: "22"
+      - link "Cache 28 in 0.67 ms" [ref=f5e236] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a937b?panel=cache
+        - generic [ref=f5e237]:
+          - img "Cache" [ref=f5e238]
+          - generic [ref=f5e243]: "28"
+          - generic [ref=f5e244]: in 0.67 ms
+      - link "1" [ref=f5e246] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a937b?panel=translation
+        - generic [ref=f5e247]:
+          - img [ref=f5e248]
+          - generic [ref=f5e253]: "1"
+      - link "Security n/a" [ref=f5e255] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a937b?panel=security
+        - generic [ref=f5e256]:
+          - img "Security" [ref=f5e257]
+          - generic [ref=f5e261]: n/a
+      - link "Twig 86 ms" [ref=f5e263] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a937b?panel=twig
+        - generic [ref=f5e264]:
+          - img "Twig" [ref=f5e265]
+          - generic [ref=f5e269]: "86"
+          - generic [ref=f5e270]: ms
+      - link "49 in 16.90 ms" [ref=f5e272] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a937b?panel=db
+        - generic [ref=f5e273]:
+          - img [ref=f5e274]
+          - generic [ref=f5e279]: "49"
+          - generic [ref=f5e280]: in 16.90 ms
+      - link "22" [ref=f5e282] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a937b?panel=doctrine_migrations
+        - generic [ref=f5e283]:
+          - img [ref=f5e284]
+          - generic [ref=f5e287]: "22"
+      - link "Symfony 7.4.13" [ref=f5e289] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/7a937b?panel=config
+        - generic [ref=f5e290]:
+          - img "Symfony" [ref=f5e292]
+          - generic [ref=f5e294]: 7.4.13
+      - generic [ref=f5e296]:
+        - img "eccube_logo_basic" [ref=f5e297]
+        - generic [ref=f5e302]: 4.3.1-p1
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f5e303] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f5e304]:
+          - img [ref=f5e305]

--- a/.playwright-mcp/page-2026-07-03T07-24-22-271Z.yml
+++ b/.playwright-mcp/page-2026-07-03T07-24-22-271Z.yml
@@ -1,0 +1,184 @@
+- generic [active] [ref=f6e1]:
+  - generic [ref=f6e3]:
+    - img [ref=f6e5]
+    - text: デバッグモードが有効になっています。
+  - generic [ref=f6e6]:
+    - banner [ref=f6e7]:
+      - generic [ref=f6e8]:
+        - generic [ref=f6e9]:
+          - generic [ref=f6e11]:
+            - generic:
+              - combobox [ref=f6e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f6e16]:
+                - searchbox "キーワードを入力" [ref=f6e17]
+                - button [ref=f6e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f6e20]:
+          - generic [ref=f6e22]:
+            - link " 新規会員登録" [ref=f6e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f6e25]: 
+              - generic [ref=f6e26]: 新規会員登録
+            - link " お気に入り" [ref=f6e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f6e29]: 
+              - generic [ref=f6e30]: お気に入り
+            - link " ログイン" [ref=f6e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f6e33]: 
+              - generic [ref=f6e34]: ログイン
+          - generic [ref=f6e37] [cursor=pointer]:
+            - generic [ref=f6e38]:
+              - text: 
+              - generic [ref=f6e39]: "1"
+            - generic [ref=f6e41]: ￥3,080
+      - heading "EC-CUBE SHOP" [level=1] [ref=f6e46]:
+        - link "EC-CUBE SHOP" [ref=f6e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f6e50]:
+        - listitem [ref=f6e51]:
+          - link "新入荷" [ref=f6e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f6e53]:
+          - link "ジェラート" [ref=f6e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f6e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f6e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f6e57]:
+          - link "アイスサンド" [ref=f6e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f6e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f6e61]:
+      - heading "クーポンコードの入力" [level=1] [ref=f6e64]
+      - generic [ref=f6e67]:
+        - generic [ref=f6e69]: 利用するクーポンコードを入力してください。
+        - generic [ref=f6e70]:
+          - generic [ref=f6e71]:
+            - generic [ref=f6e72]:
+              - term [ref=f6e73]
+              - definition [ref=f6e74]:
+                - generic [ref=f6e75]:
+                  - generic [ref=f6e76]:
+                    - radio "クーポンを利用しない" [ref=f6e77]
+                    - generic [ref=f6e78]: クーポンを利用しない
+                  - generic [ref=f6e79]:
+                    - radio "クーポンを利用する" [checked] [ref=f6e80]
+                    - generic [ref=f6e81]: クーポンを利用する
+            - generic [ref=f6e82]:
+              - term [ref=f6e83]:
+                - generic [ref=f6e84]: クーポンコード
+              - definition [ref=f6e85]:
+                - textbox "クーポンコード" [ref=f6e86]
+          - generic [ref=f6e89]:
+            - button "登録する" [ref=f6e90] [cursor=pointer]
+            - link "戻る" [ref=f6e91] [cursor=pointer]:
+              - /url: http://localhost:8080/shopping
+    - contentinfo [ref=f6e92]:
+      - generic [ref=f6e94]:
+        - list [ref=f6e95]:
+          - listitem [ref=f6e96]:
+            - link "当サイトについて" [ref=f6e97] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f6e98]:
+            - link "プライバシーポリシー" [ref=f6e99] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f6e100]:
+            - link "特定商取引法に基づく表記" [ref=f6e101] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f6e102]:
+            - link "お問い合わせ" [ref=f6e103] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f6e104]:
+          - link "EC-CUBE SHOP" [ref=f6e106] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f6e107]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f6e108]:
+    - generic [ref=f6e111]:
+      - link "200 @ plugin_coupon_shopping" [ref=f6e113] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/c03ac2?panel=request
+        - generic [ref=f6e114]:
+          - generic [ref=f6e115]: "200"
+          - generic [ref=f6e116]: "@"
+          - generic [ref=f6e117]: plugin_coupon_shopping
+      - link "214 ms" [ref=f6e119] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/c03ac2?panel=time
+        - generic [ref=f6e120]:
+          - generic [ref=f6e121]: "214"
+          - generic [ref=f6e122]: ms
+      - link "12.0 MiB" [ref=f6e124] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/c03ac2?panel=time
+        - generic [ref=f6e125]:
+          - generic [ref=f6e126]: "12.0"
+          - generic [ref=f6e127]: MiB
+      - link "Cache 2" [ref=f6e129] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/c03ac2?panel=form
+        - generic [ref=f6e130]:
+          - img "Cache" [ref=f6e131]
+          - generic [ref=f6e137]: "2"
+      - link "Logger 11" [ref=f6e139] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/c03ac2?panel=logger
+        - generic [ref=f6e140]:
+          - img "Logger" [ref=f6e141]
+          - generic [ref=f6e145]: "11"
+      - link "Cache 20 in 0.38 ms" [ref=f6e147] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/c03ac2?panel=cache
+        - generic [ref=f6e148]:
+          - img "Cache" [ref=f6e149]
+          - generic [ref=f6e154]: "20"
+          - generic [ref=f6e155]: in 0.38 ms
+      - link "27" [ref=f6e157] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/c03ac2?panel=translation
+        - generic [ref=f6e158]:
+          - img [ref=f6e159]
+          - generic [ref=f6e164]: "27"
+      - link "Security n/a" [ref=f6e166] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/c03ac2?panel=security
+        - generic [ref=f6e167]:
+          - img "Security" [ref=f6e168]
+          - generic [ref=f6e172]: n/a
+      - link "Twig 76 ms" [ref=f6e174] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/c03ac2?panel=twig
+        - generic [ref=f6e175]:
+          - img "Twig" [ref=f6e176]
+          - generic [ref=f6e180]: "76"
+          - generic [ref=f6e181]: ms
+      - link "21 in 7.30 ms" [ref=f6e183] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/c03ac2?panel=db
+        - generic [ref=f6e184]:
+          - img [ref=f6e185]
+          - generic [ref=f6e190]: "21"
+          - generic [ref=f6e191]: in 7.30 ms
+      - link "22" [ref=f6e193] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/c03ac2?panel=doctrine_migrations
+        - generic [ref=f6e194]:
+          - img [ref=f6e195]
+          - generic [ref=f6e198]: "22"
+      - link "Symfony 7.4.13" [ref=f6e200] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/c03ac2?panel=config
+        - generic [ref=f6e201]:
+          - img "Symfony" [ref=f6e203]
+          - generic [ref=f6e205]: 7.4.13
+      - generic [ref=f6e207]:
+        - img "eccube_logo_basic" [ref=f6e208]
+        - generic [ref=f6e213]: 4.3.1-p1
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f6e214] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f6e215]:
+          - img [ref=f6e216]

--- a/.playwright-mcp/page-2026-08-03T05-24-56-828Z.yml
+++ b/.playwright-mcp/page-2026-08-03T05-24-56-828Z.yml
@@ -1,0 +1,119 @@
+- generic [active] [ref=e1]:
+  - banner [ref=e2]:
+    - generic [ref=e3]:
+      - heading "Symfony Exception" [level=1] [ref=e4]
+      - link "Symfony Docs" [ref=e8] [cursor=pointer]:
+        - /url: https://symfony.com/doc/7.4.13/index.html
+  - generic [ref=e12]:
+    - generic [ref=e14]:
+      - heading [level=2] [ref=e15]:
+        - link "IOException" [ref=e16] [cursor=pointer]:
+          - /url: "#trace-box-1"
+      - heading "HTTP 500 Internal Server Error" [level=2] [ref=e17]
+    - 'heading "Failed to remove file \"/var/www/html/var/cache/dev/.!!8Lz/URI/4.19.0,81373184c6f30942fadaf90d195b52503f5834e7,1.ser\": unlink(/var/www/html/var/cache/dev/.!!8Lz/URI/4.19.0,81373184c6f30942fadaf90d195b52503f5834e7,1.ser): Permission denied" [level=1] [ref=e20]'
+  - generic [ref=e25]:
+    - tablist [ref=e26]:
+      - tab "Exception" [selected] [ref=e27] [cursor=pointer]
+      - tab "Stack Trace" [ref=e28] [cursor=pointer]
+    - tabpanel [ref=e29]:
+      - generic [ref=e32]:
+        - generic [ref=e33]:
+          - heading "Symfony\\Component\\Filesystem\\Exception\\ IOException" [level=3] [ref=e38] [cursor=pointer]:
+            - generic [ref=e39]: Symfony\Component\Filesystem\Exception\
+            - text: IOException
+          - group [ref=e40]:
+            - generic "Show exception properties" [ref=e41] [cursor=pointer]
+        - generic [ref=e42]:
+          - generic [ref=e48] [cursor=pointer]:
+            - text: in
+            - link [ref=e49]:
+              - /url: file:///var/www/html/vendor/symfony/filesystem/Filesystem.php#L197
+              - text: /var/www/html/vendor/symfony/filesystem/
+              - strong [ref=e50]: Filesystem.php
+            - text: (line 197)
+          - generic [ref=e56] [cursor=pointer]:
+            - text: in
+            - link [ref=e57]:
+              - /url: file:///var/www/html/vendor/symfony/filesystem/Filesystem.php#L185
+              - text: /var/www/html/vendor/symfony/filesystem/
+              - strong [ref=e58]: Filesystem.php
+            - text: ":: doRemove (line 185)"
+          - generic [ref=e64] [cursor=pointer]:
+            - text: in
+            - link [ref=e65]:
+              - /url: file:///var/www/html/vendor/symfony/filesystem/Filesystem.php#L185
+              - text: /var/www/html/vendor/symfony/filesystem/
+              - strong [ref=e66]: Filesystem.php
+            - text: ":: doRemove (line 185)"
+          - generic [ref=e72] [cursor=pointer]:
+            - text: in
+            - link [ref=e73]:
+              - /url: file:///var/www/html/vendor/symfony/filesystem/Filesystem.php#L153
+              - text: /var/www/html/vendor/symfony/filesystem/
+              - strong [ref=e74]: Filesystem.php
+            - text: ":: doRemove (line 153)"
+          - generic [ref=e80] [cursor=pointer]:
+            - text: in
+            - link [ref=e81]:
+              - /url: file:///var/www/html/vendor/exercise/htmlpurifier-bundle/src/CacheWarmer/SerializerCacheWarmer.php#L43
+              - text: /var/www/html/vendor/exercise/htmlpurifier-bundle/src/CacheWarmer/
+              - strong [ref=e82]: SerializerCacheWarmer.php
+            - text: "-> remove (line 43)"
+          - generic [ref=e88] [cursor=pointer]:
+            - text: in
+            - link [ref=e89]:
+              - /url: file:///var/www/html/vendor/symfony/http-kernel/CacheWarmer/CacheWarmerAggregate.php#L96
+              - text: /var/www/html/vendor/symfony/http-kernel/CacheWarmer/
+              - strong [ref=e90]: CacheWarmerAggregate.php
+            - text: "-> warmUp (line 96)"
+          - generic [ref=e96] [cursor=pointer]:
+            - text: in
+            - link [ref=e97]:
+              - /url: file:///var/www/html/vendor/symfony/http-kernel/Kernel.php#L563
+              - text: /var/www/html/vendor/symfony/http-kernel/
+              - strong [ref=e98]: Kernel.php
+            - text: "-> warmUp (line 563)"
+          - generic [ref=e104] [cursor=pointer]:
+            - text: in
+            - link [ref=e105]:
+              - /url: file:///var/www/html/vendor/symfony/http-kernel/Kernel.php#L762
+              - text: /var/www/html/vendor/symfony/http-kernel/
+              - strong [ref=e106]: Kernel.php
+            - text: "-> initializeContainer (line 762)"
+          - generic [ref=e112] [cursor=pointer]:
+            - text: in
+            - link [ref=e113]:
+              - /url: file:///var/www/html/vendor/symfony/http-kernel/Kernel.php#L172
+              - text: /var/www/html/vendor/symfony/http-kernel/
+              - strong [ref=e114]: Kernel.php
+            - text: "-> preBoot (line 172)"
+          - generic [ref=e115]:
+            - generic [ref=e116] [cursor=pointer]:
+              - generic [ref=e120]: Kernel
+              - text: "->handle()"
+              - generic [ref=e121]:
+                - text: in
+                - link [ref=e122]:
+                  - /url: file:///var/www/html/index.php#L100
+                  - text: /var/www/html/
+                  - strong [ref=e123]: index.php
+                - text: (line 100)
+            - list [ref=e129]:
+              - listitem [ref=e130]:
+                - code [ref=e131]: "}"
+              - listitem [ref=e132]:
+                - code [ref=e133]: "}"
+              - listitem [ref=e134]:
+                - code [ref=e135]: "}"
+              - listitem [ref=e136]:
+                - code
+              - listitem [ref=e137]:
+                - code [ref=e138]: $kernel = new Kernel($env, $debug);
+              - listitem [ref=e139]:
+                - code [ref=e140]: $response = $kernel->handle($request);
+              - listitem [ref=e141]:
+                - code [ref=e142]: $response->send();
+              - listitem [ref=e143]:
+                - code [ref=e144]: $kernel->terminate($request, $response);
+              - listitem [ref=e145]:
+                - code

--- a/.playwright-mcp/page-2026-08-03T05-25-29-897Z.yml
+++ b/.playwright-mcp/page-2026-08-03T05-25-29-897Z.yml
@@ -1,0 +1,17 @@
+- generic [ref=f1e1]:
+  - generic [ref=f1e5]:
+    - generic [ref=f1e8]:
+      - paragraph [ref=f1e9]
+      - textbox "ログインID" [active] [ref=f1e12]
+      - textbox "パスワード" [ref=f1e14]
+      - button "ログイン" [ref=f1e16] [cursor=pointer]
+    - paragraph [ref=f1e18]: Copyright © 2000-2026 EC-CUBE CO.,LTD. All Rights Reserved.
+  - region "Symfony Web Debug Toolbar" [ref=f1e19]:
+    - generic [ref=f1e22]:
+      - link "Symfony Loading…" [ref=f1e24] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/e27abd?panel=request
+        - generic [ref=f1e25]:
+          - img "Symfony" [ref=f1e26]
+          - generic [ref=f1e28]: Loading…
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f1e29] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f1e30]

--- a/.playwright-mcp/page-2026-08-03T05-25-41-789Z.yml
+++ b/.playwright-mcp/page-2026-08-03T05-25-41-789Z.yml
@@ -1,0 +1,281 @@
+- generic [active] [ref=f2e1]:
+  - banner [ref=f2e2]:
+    - generic [ref=f2e3]:
+      - heading [level=1] [ref=f2e5]
+      - text: 
+      - link "EC-CUBE SHOP" [ref=f2e7] [cursor=pointer]:
+        - /url: http://localhost:8080/
+        - text: EC-CUBE SHOP
+        - generic [ref=f2e8]: 
+      - generic [ref=f2e9] [cursor=pointer]:
+        - generic [ref=f2e10]: 
+        - text: 管理者 様
+        - generic [ref=f2e11]: 
+  - generic [ref=f2e12]:
+    - navigation [ref=f2e14]:
+      - list [ref=f2e15]:
+        - listitem [ref=f2e16]:
+          - link "ホーム" [ref=f2e17] [cursor=pointer]:
+            - /url: http://localhost:8080/admin/
+            - generic [ref=f2e18]: 
+            - text: ホーム
+        - listitem [ref=f2e19]:
+          - link "商品管理 " [ref=f2e20] [cursor=pointer]:
+            - /url: "#nav-product"
+            - generic [ref=f2e21]: 
+            - text: 商品管理 
+        - listitem [ref=f2e22]:
+          - link "受注管理 " [ref=f2e23] [cursor=pointer]:
+            - /url: "#nav-order"
+            - generic [ref=f2e24]: 
+            - text: 受注管理 
+        - listitem [ref=f2e25]:
+          - link "会員管理 " [ref=f2e26] [cursor=pointer]:
+            - /url: "#nav-customer"
+            - generic [ref=f2e27]: 
+            - text: 会員管理 
+        - listitem [ref=f2e28]:
+          - link "コンテンツ管理 " [ref=f2e29] [cursor=pointer]:
+            - /url: "#nav-content"
+            - generic [ref=f2e30]: 
+            - text: コンテンツ管理 
+        - listitem [ref=f2e31]:
+          - link "設定 " [ref=f2e32] [cursor=pointer]:
+            - /url: "#nav-setting"
+            - generic [ref=f2e33]: 
+            - text: 設定 
+          - text:  
+        - listitem [ref=f2e34]:
+          - link "オーナーズストア " [ref=f2e35] [cursor=pointer]:
+            - /url: "#nav-store"
+            - generic [ref=f2e36]: 
+            - text: オーナーズストア 
+          - text:  
+        - listitem [ref=f2e37]:
+          - link "情報 " [ref=f2e38] [cursor=pointer]:
+            - /url: "#others"
+            - generic [ref=f2e39]: 
+            - text: 情報 
+    - generic [ref=f2e40]:
+      - heading "ホーム" [level=2] [ref=f2e43]
+      - alert [ref=f2e44]:
+        - generic [ref=f2e45]: 
+        - text: デバッグモードが有効になっています。
+        - button "Close" [ref=f2e46] [cursor=pointer]
+      - alert [ref=f2e47]:
+        - generic [ref=f2e48]: 
+        - generic [ref=f2e49]:
+          - text: 管理画面URLは、セキュリティのため推測されにくいものを設定してください。「
+          - link "セキュリティ管理" [ref=f2e50] [cursor=pointer]:
+            - /url: http://localhost:8080/admin/setting/system/security
+          - text: 」から設定できます。
+        - button "Close" [ref=f2e51] [cursor=pointer]
+      - generic [ref=f2e54]:
+        - generic [ref=f2e55]:
+          - generic [ref=f2e57]:
+            - link "注文状況" [ref=f2e59] [cursor=pointer]:
+              - /url: http://localhost:8080/admin/order
+            - generic [ref=f2e60]:
+              - link "新規受付 0" [ref=f2e62] [cursor=pointer]:
+                - /url: http://localhost:8080/admin/order?order_status_id=1
+                - generic [ref=f2e63]:
+                  - generic [ref=f2e64]: 新規受付
+                  - generic [ref=f2e65]: "0"
+              - link "入金済み 0" [ref=f2e67] [cursor=pointer]:
+                - /url: http://localhost:8080/admin/order?order_status_id=6
+                - generic [ref=f2e68]:
+                  - generic [ref=f2e69]: 入金済み
+                  - generic [ref=f2e70]: "0"
+              - link "対応中 0" [ref=f2e72] [cursor=pointer]:
+                - /url: http://localhost:8080/admin/order?order_status_id=4
+                - generic [ref=f2e73]:
+                  - generic [ref=f2e74]: 対応中
+                  - generic [ref=f2e75]: "0"
+          - generic [ref=f2e77]:
+            - generic [ref=f2e78]: 売上状況
+            - generic [ref=f2e80]:
+              - generic [ref=f2e81]:
+                - generic [ref=f2e82]:
+                  - generic [ref=f2e83]: ￥0 / 0 件
+                  - text: 今月の売上金額 / 売上件数
+                - generic [ref=f2e84]:
+                  - generic [ref=f2e85]: ￥0 / 0 件
+                  - text: 今日の売上金額 / 売上件数
+                - generic [ref=f2e86]:
+                  - generic [ref=f2e87]: ￥0 / 0 件
+                  - text: 昨日の売上金額 / 売上件数
+              - tablist [ref=f2e90]:
+                - tab "週間" [selected] [ref=f2e91] [cursor=pointer]
+                - tab "月間" [ref=f2e92] [cursor=pointer]
+                - tab "年間" [ref=f2e93] [cursor=pointer]
+              - tabpanel "週間" [ref=f2e97]
+        - generic [ref=f2e99]:
+          - generic [ref=f2e101]:
+            - generic [ref=f2e102]: ショップ状況
+            - generic [ref=f2e104]:
+              - link "在庫切れ商品数 0" [ref=f2e106] [cursor=pointer]:
+                - /url: http://localhost:8080/admin/search_nonstock
+                - generic [ref=f2e107]:
+                  - generic [ref=f2e108]: 
+                  - generic [ref=f2e110]: 在庫切れ商品数
+                  - generic [ref=f2e111]: "0"
+              - link "取扱商品数 2" [ref=f2e113] [cursor=pointer]:
+                - /url: http://localhost:8080/admin/product
+                - generic [ref=f2e114]:
+                  - generic [ref=f2e115]: 
+                  - generic [ref=f2e117]: 取扱商品数
+                  - generic [ref=f2e118]: "2"
+              - link "会員数 0" [ref=f2e120] [cursor=pointer]:
+                - /url: http://localhost:8080/admin/search_customer
+                - generic [ref=f2e121]:
+                  - generic [ref=f2e122]: 
+                  - generic [ref=f2e124]: 会員数
+                  - generic [ref=f2e125]: "0"
+          - generic [ref=f2e127]:
+            - generic [ref=f2e128]: おすすめのプラグイン
+            - generic [ref=f2e130]:
+              - generic [ref=f2e131]:
+                - link [ref=f2e133] [cursor=pointer]:
+                  - /url: "#"
+                  - img "【EC-CUBE公式】Amazon Pay V2プラグイン(4.2/4.3系)" [ref=f2e134]
+                - generic [ref=f2e135]:
+                  - link "【EC-CUBE公式】Amazon Pay V2プラグイン(4.2/4.3系)" [ref=f2e136] [cursor=pointer]:
+                    - /url: "#"
+                  - paragraph [ref=f2e137]: 【新規顧客獲得・リピート購入率向上に期待】 「マーケティング効果」の見込めるAmazon Payの魅力
+              - generic [ref=f2e138]:
+                - link [ref=f2e140] [cursor=pointer]:
+                  - /url: "#"
+                  - img "EC-CUBEセキュリティチェックプラグイン(4.2/4.3系)" [ref=f2e141]
+                - generic [ref=f2e142]:
+                  - link "EC-CUBEセキュリティチェックプラグイン(4.2/4.3系)" [ref=f2e143] [cursor=pointer]:
+                    - /url: "#"
+                  - paragraph [ref=f2e144]: 「EC-CUBE バージョン別運用環境セキュリティチェックリスト」内の対応必須項目を中心に、利用環境のチェックを自動でおこなうことができるツールです。
+              - generic [ref=f2e145]:
+                - link [ref=f2e147] [cursor=pointer]:
+                  - /url: "#"
+                  - img "メルマガ管理プラグイン(4.2/4.3系)" [ref=f2e148]
+                - generic [ref=f2e149]:
+                  - link "メルマガ管理プラグイン(4.2/4.3系)" [ref=f2e150] [cursor=pointer]:
+                    - /url: "#"
+                  - paragraph [ref=f2e151]: メールマガジンの配信を行います。
+              - generic [ref=f2e152]:
+                - link [ref=f2e154] [cursor=pointer]:
+                  - /url: "#"
+                  - img "売上集計プラグイン(4.2/4.3系)" [ref=f2e155]
+                - generic [ref=f2e156]:
+                  - link "売上集計プラグイン(4.2/4.3系)" [ref=f2e157] [cursor=pointer]:
+                    - /url: "#"
+                  - paragraph [ref=f2e158]: 売上集計機能を追加します。
+              - generic [ref=f2e159]:
+                - link [ref=f2e161] [cursor=pointer]:
+                  - /url: "#"
+                  - img "商品レビュー管理プラグイン(4.2/4.3系)" [ref=f2e162]
+                - generic [ref=f2e163]:
+                  - link "商品レビュー管理プラグイン(4.2/4.3系)" [ref=f2e164] [cursor=pointer]:
+                    - /url: "#"
+                  - paragraph [ref=f2e165]: 商品レビュー機能を追加します。
+              - generic [ref=f2e166]:
+                - link [ref=f2e168] [cursor=pointer]:
+                  - /url: "#"
+                  - img "関連商品プラグイン(4.2/4.3系)" [ref=f2e169]
+                - generic [ref=f2e170]:
+                  - link "関連商品プラグイン(4.2/4.3系)" [ref=f2e171] [cursor=pointer]:
+                    - /url: "#"
+                  - paragraph [ref=f2e172]: 関連商品の登録を行うことができます。
+              - generic [ref=f2e173]:
+                - link [ref=f2e175] [cursor=pointer]:
+                  - /url: "#"
+                  - img "おすすめ商品管理プラグイン(4.2/4.3系)" [ref=f2e176]
+                - generic [ref=f2e177]:
+                  - link "おすすめ商品管理プラグイン(4.2/4.3系)" [ref=f2e178] [cursor=pointer]:
+                    - /url: "#"
+                  - paragraph [ref=f2e179]: おすすめ商品の表示をブロックとして追加することができるプラグインです。
+            - generic [ref=f2e180]:
+              - text: ">"
+              - link "オーナーズストア" [ref=f2e181] [cursor=pointer]:
+                - /url: http://localhost:8080/admin/store/plugin/api/search/page
+          - generic [ref=f2e183]:
+            - generic [ref=f2e184]: お知らせ
+            - iframe [ref=f2e187]:
+              - generic [ref=f3e6]:
+                - generic [ref=f3e7]:
+                  - term [ref=f3e8]:
+                    - link "セキュリティ対策まとめ" [ref=f3e9] [cursor=pointer]:
+                      - /url: https://www.ec-cube.net/info/security/?argument=2qpV46CP&dmai=a5f1154a4b3f68
+                  - definition [ref=f3e10]: より安全に利用いただくために必ずお読みください
+                - generic [ref=f3e11]:
+                  - term [ref=f3e12]:
+                    - link "セキュリティへの取り組み" [ref=f3e13] [cursor=pointer]:
+                      - /url: https://www.ec-cube.net/info/security/efforts.php?argument=2qpV46CP&dmai=20220210_effort
+                  - definition [ref=f3e14]: 取り組みについてご理解いただき、適切にセキュリティ対応をしていただきますようお願いいたします
+                - generic [ref=f3e15]:
+                  - term [ref=f3e16]:
+                    - link "管理・運用マニュアル" [ref=f3e17] [cursor=pointer]:
+                      - /url: https://www.ec-cube.net/manual/ec-cube4/
+                  - definition [ref=f3e18]: EC-CUBEの管理画面の使い方にお困りの方へ
+                - generic [ref=f3e19]:
+                  - term [ref=f3e20]:
+                    - link "EC-CUBE公式メルマガ" [ref=f3e21] [cursor=pointer]:
+                      - /url: https://www.ec-cube.net/mail/?argument=2qpV46CP&dmai=a5f1155de3b0bd
+                  - definition [ref=f3e22]: ニュースやECのノウハウ・セキュリティ情報をお届け
+  - region "Symfony Web Debug Toolbar" [ref=f2e189]:
+    - generic [ref=f2e192]:
+      - link "200 Redirect @ admin_homepage" [ref=f2e194] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d249b7?panel=request
+        - generic [ref=f2e195]:
+          - generic [ref=f2e196]: "200"
+          - img "Redirect" [ref=f2e198]
+          - generic [ref=f2e201]: "@"
+          - generic [ref=f2e202]: admin_homepage
+      - link "-93 ms" [ref=f2e204] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d249b7?panel=time
+        - generic [ref=f2e205]:
+          - generic [ref=f2e206]: "-93"
+          - generic [ref=f2e207]: ms
+      - link "8.0 MiB" [ref=f2e209] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d249b7?panel=time
+        - generic [ref=f2e210]:
+          - generic [ref=f2e211]: "8.0"
+          - generic [ref=f2e212]: MiB
+      - generic [ref=f2e213]: "1"
+      - link "Logger 477" [ref=f2e221] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d249b7?panel=logger
+        - generic [ref=f2e222]:
+          - img "Logger" [ref=f2e223]
+          - generic [ref=f2e227]: "477"
+      - link "Cache 10 in 0.07 ms" [ref=f2e229] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d249b7?panel=cache
+        - generic [ref=f2e230]:
+          - img "Cache" [ref=f2e231]
+          - generic [ref=f2e236]: "10"
+          - generic [ref=f2e237]: in 0.07 ms
+      - link "1" [ref=f2e239] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d249b7?panel=translation
+      - link "Security admin" [ref=f2e248] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d249b7?panel=security
+        - generic [ref=f2e249]:
+          - img "Security" [ref=f2e250]
+          - generic [ref=f2e254]: admin
+      - link "Twig 53 ms" [ref=f2e256] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d249b7?panel=twig
+        - generic [ref=f2e257]:
+          - img "Twig" [ref=f2e258]
+          - generic [ref=f2e262]: "53"
+          - generic [ref=f2e263]: ms
+      - link "15 in 2.21 ms" [ref=f2e265] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d249b7?panel=db
+        - generic [ref=f2e266]:
+          - generic [ref=f2e272]: "15"
+          - generic [ref=f2e273]: in 2.21 ms
+      - link "22" [ref=f2e275] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d249b7?panel=doctrine_migrations
+      - link "Symfony 7.4.13" [ref=f2e282] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/d249b7?panel=config
+        - generic [ref=f2e283]:
+          - img "Symfony" [ref=f2e285]
+          - generic [ref=f2e287]: 7.4.13
+      - generic [ref=f2e289]:
+        - img "eccube_logo_basic" [ref=f2e290]
+        - generic [ref=f2e295]: 4.3.1-p1
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f2e296] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f2e297]

--- a/.playwright-mcp/page-2026-08-03T05-25-48-517Z.yml
+++ b/.playwright-mcp/page-2026-08-03T05-25-48-517Z.yml
@@ -1,0 +1,310 @@
+- generic [active] [ref=f4e1]:
+  - banner [ref=f4e2]:
+    - generic [ref=f4e3]:
+      - heading [level=1] [ref=f4e5]
+      - text: 
+      - link "EC-CUBE SHOP" [ref=f4e7] [cursor=pointer]:
+        - /url: http://localhost:8080/
+        - text: EC-CUBE SHOP
+        - generic [ref=f4e8]: 
+      - generic [ref=f4e9] [cursor=pointer]:
+        - generic [ref=f4e10]: 
+        - text: 管理者 様
+        - generic [ref=f4e11]: 
+  - generic [ref=f4e12]:
+    - navigation [ref=f4e14]:
+      - list [ref=f4e15]:
+        - listitem [ref=f4e16]:
+          - link "ホーム" [ref=f4e17] [cursor=pointer]:
+            - /url: http://localhost:8080/admin/
+            - generic [ref=f4e18]: 
+            - text: ホーム
+        - listitem [ref=f4e19]:
+          - link "商品管理 " [ref=f4e20] [cursor=pointer]:
+            - /url: "#nav-product"
+            - generic [ref=f4e21]: 
+            - text: 商品管理 
+        - listitem [ref=f4e22]:
+          - link "受注管理 " [ref=f4e23] [cursor=pointer]:
+            - /url: "#nav-order"
+            - generic [ref=f4e24]: 
+            - text: 受注管理 
+        - listitem [ref=f4e25]:
+          - link "会員管理 " [ref=f4e26] [cursor=pointer]:
+            - /url: "#nav-customer"
+            - generic [ref=f4e27]: 
+            - text: 会員管理 
+        - listitem [ref=f4e28]:
+          - link "コンテンツ管理 " [expanded] [ref=f4e29] [cursor=pointer]:
+            - /url: "#nav-content"
+            - generic [ref=f4e30]: 
+            - text: コンテンツ管理 
+          - list [ref=f4e31]:
+            - listitem [ref=f4e32]:
+              - link "新着情報管理" [ref=f4e33] [cursor=pointer]:
+                - /url: http://localhost:8080/admin/content/news
+            - listitem [ref=f4e34]:
+              - link "ファイル管理" [ref=f4e35] [cursor=pointer]:
+                - /url: http://localhost:8080/admin/content/file_manager
+            - listitem [ref=f4e36]:
+              - link "レイアウト管理" [ref=f4e37] [cursor=pointer]:
+                - /url: http://localhost:8080/admin/content/layout
+            - listitem [ref=f4e38]:
+              - link "ページ管理" [ref=f4e39] [cursor=pointer]:
+                - /url: http://localhost:8080/admin/content/page
+            - listitem [ref=f4e40]:
+              - link "CSS管理" [ref=f4e41] [cursor=pointer]:
+                - /url: http://localhost:8080/admin/content/css
+            - listitem [ref=f4e42]:
+              - link "JavaScript管理" [ref=f4e43] [cursor=pointer]:
+                - /url: http://localhost:8080/admin/content/js
+            - listitem [ref=f4e44]:
+              - link "ブロック管理" [ref=f4e45] [cursor=pointer]:
+                - /url: http://localhost:8080/admin/content/block
+            - listitem [ref=f4e46]:
+              - link "キャッシュ管理" [ref=f4e47] [cursor=pointer]:
+                - /url: http://localhost:8080/admin/content/cache
+            - listitem [ref=f4e48]:
+              - link "メンテナンス管理" [ref=f4e49] [cursor=pointer]:
+                - /url: http://localhost:8080/admin/content/maintenance
+            - listitem [ref=f4e50]:
+              - link "エージェントコマース" [ref=f4e51] [cursor=pointer]:
+                - /url: http://localhost:8080/admin/content/agent_commerce
+        - listitem [ref=f4e52]:
+          - link "設定 " [ref=f4e53] [cursor=pointer]:
+            - /url: "#nav-setting"
+            - generic [ref=f4e54]: 
+            - text: 設定 
+          - text:  
+        - listitem [ref=f4e55]:
+          - link "オーナーズストア " [ref=f4e56] [cursor=pointer]:
+            - /url: "#nav-store"
+            - generic [ref=f4e57]: 
+            - text: オーナーズストア 
+          - text:  
+        - listitem [ref=f4e58]:
+          - link "情報 " [ref=f4e59] [cursor=pointer]:
+            - /url: "#others"
+            - generic [ref=f4e60]: 
+            - text: 情報 
+    - generic [ref=f4e61]:
+      - generic [ref=f4e63]:
+        - heading "ページ管理" [level=2] [ref=f4e64]
+        - generic [ref=f4e65]: コンテンツ管理
+      - alert [ref=f4e66]:
+        - generic [ref=f4e67]: 
+        - text: この機能の利用頻度が低い場合、使用しない間は無効化することでセキュリティを更に向上させることができます。環境変数 ECCUBE_RESTRICT_FILE_UPLOAD を 1 に設定することで機能を無効化することが可能です。
+        - button "Close" [ref=f4e68] [cursor=pointer]
+      - alert [ref=f4e69]:
+        - generic [ref=f4e70]: 
+        - text: デバッグモードが有効になっています。
+        - button "Close" [ref=f4e71] [cursor=pointer]
+      - generic [ref=f4e72]:
+        - generic [ref=f4e75]:
+          - generic [ref=f4e76]:
+            - generic [ref=f4e78]:
+              - generic [ref=f4e79]: ページ設定
+              - link "" [ref=f4e81] [cursor=pointer]:
+                - /url: "#pageDetail"
+            - generic [ref=f4e84]:
+              - generic [ref=f4e85]:
+                - generic [ref=f4e86]:
+                  - text: ページ名
+                  - generic [ref=f4e87]: 必須
+                - textbox [ref=f4e89]: 商品購入/クーポン利用
+              - generic [ref=f4e90]:
+                - generic [ref=f4e91]:
+                  - text: URL
+                  - generic [ref=f4e92]: 必須
+                - generic [ref=f4e93]: http://localhost:8080/plugin/coupon/shopping/shopping_coupon
+              - generic [ref=f4e96]:
+                - generic [ref=f4e97]:
+                  - generic [ref=f4e98]:
+                    - text: ファイル名
+                    - generic [ref=f4e99]: 
+                  - generic [ref=f4e100]: 必須
+                - generic [ref=f4e101]: app/template/default/Coupon44/Resource/template/default/shopping_coupon.twig
+              - generic [ref=f4e104]:
+                - generic [ref=f4e105]:
+                  - generic [ref=f4e106]:
+                    - text: コード
+                    - generic [ref=f4e107]: 
+                  - generic [ref=f4e108]: 必須
+                - generic [ref=f4e110]:
+                  - textbox [ref=f4e111]
+                  - generic [ref=f4e113]:
+                    - generic [ref=f4e114]: "1"
+                    - generic [ref=f4e115]: "2"
+                    - generic [ref=f4e116]: "3"
+                    - generic [ref=f4e117]: "4"
+                    - generic [ref=f4e118]: "5"
+                    - generic [ref=f4e119]: "6"
+                    - generic [ref=f4e120]: "7"
+                    - generic [ref=f4e121]: "8"
+                    - generic [ref=f4e122]: "9"
+                    - generic [ref=f4e123]: "10"
+                    - generic [ref=f4e124]: "11"
+                    - generic [ref=f4e125]: "12"
+                    - generic [ref=f4e126]: "13"
+                    - generic [ref=f4e127]:
+                      - text: "14"
+                      - button [expanded] [ref=f4e128] [cursor=pointer]
+                    - generic [ref=f4e129]:
+                      - text: "15"
+                      - button [expanded] [ref=f4e130] [cursor=pointer]
+                    - generic [ref=f4e131]:
+                      - text: "16"
+                      - button [expanded] [ref=f4e132] [cursor=pointer]
+                    - generic [ref=f4e133]:
+                      - text: "17"
+                      - button [expanded] [ref=f4e134] [cursor=pointer]
+                    - generic [ref=f4e135]: "18"
+                    - generic [ref=f4e136]: "19"
+                    - generic [ref=f4e137]:
+                      - text: "20"
+                      - button [expanded] [ref=f4e138] [cursor=pointer]
+                    - generic [ref=f4e139]: "21"
+                    - generic [ref=f4e140]: "22"
+                    - generic [ref=f4e141]: "23"
+                    - generic [ref=f4e142]: "24"
+                  - generic [ref=f4e144]:
+                    - generic:
+                      - generic: "{#¬"
+                      - generic: ·This·file·is·part·of·the·Coupon·plugin¬
+                      - generic: ¬
+                      - generic: ·Copyright(c)·EC-CUBE·CO.,LTD.·All·Rights·Reserved.¬
+                      - generic: ·http://www.ec-cube.co.jp/¬
+                      - generic: ¬
+                      - generic: ·For·the·full·copyright·and·license·information,·please·view·the·LICENSE¬
+                      - generic: ·file·that·was·distributed·with·this·source·code.¬
+                      - generic: "#}¬"
+                      - generic: "{%·extends·'default_frame.twig'·%}¬"
+                      - generic: ¬
+                      - generic: "{%·set·body_class·=·'cart_page'·%}¬"
+                      - generic: "{%·block·javascript·%}¬"
+                      - generic:
+                        - generic: ····
+                        - text: <script>¬
+                      - generic: "········$(function()·{¬"
+                      - generic: "············$('input[name~=\"coupon_use[coupon_use]\"]').change(function·()·{¬"
+                      - generic: "················if($(this).val()·==·0)·{¬"
+                      - generic: ····················$('#coupon_use_coupon_cd').attr('readonly',·'');¬
+                      - generic: ····················$('#coupon_use_coupon_cd').css('background-color',·'#eee');¬
+                      - generic: "················}·else·{¬"
+                      - generic: ····················$('#coupon_use_coupon_cd').removeAttr('readonly');¬
+                      - generic: ····················$('#coupon_use_coupon_cd').css('background-color',·'white');¬
+                      - generic: "················}¬"
+                      - generic: "············});¬"
+          - generic [ref=f4e150]:
+            - generic [ref=f4e152]:
+              - generic [ref=f4e155]:
+                - text: レイアウト設定
+                - generic [ref=f4e156]: 
+              - link "" [ref=f4e158] [cursor=pointer]:
+                - /url: "#pageLayout"
+            - generic [ref=f4e161]:
+              - generic [ref=f4e162]:
+                - generic [ref=f4e163]: PC
+                - combobox [ref=f4e165]:
+                  - option "---"
+                  - option "下層ページ用レイアウト" [selected]
+                  - option "トップページ用レイアウト"
+              - generic [ref=f4e166]:
+                - generic [ref=f4e167]: モバイル
+                - combobox [ref=f4e169]:
+                  - option "---" [selected]
+          - generic [ref=f4e170]:
+            - generic [ref=f4e172]:
+              - generic [ref=f4e174]:
+                - text: メタ設定
+                - generic [ref=f4e175]: 
+              - link "" [ref=f4e177] [cursor=pointer]:
+                - /url: "#pageMeta"
+            - generic [ref=f4e180]:
+              - generic [ref=f4e181]:
+                - generic [ref=f4e182]: author
+                - textbox [ref=f4e184]
+              - generic [ref=f4e185]:
+                - generic [ref=f4e186]: description
+                - textbox [ref=f4e188]
+              - generic [ref=f4e189]:
+                - generic [ref=f4e190]: keyword
+                - textbox [ref=f4e192]
+              - generic [ref=f4e193]:
+                - generic [ref=f4e194]: robot
+                - textbox [ref=f4e196]: noindex
+              - generic [ref=f4e197]:
+                - generic [ref=f4e199]:
+                  - text: metatag
+                  - generic [ref=f4e200]: 
+                - textbox [ref=f4e202]
+        - generic [ref=f4e205]:
+          - link "ページ管理" [ref=f4e208] [cursor=pointer]:
+            - /url: http://localhost:8080/admin/content/page
+            - generic [ref=f4e209]: 
+            - text: ページ管理
+          - button "登録" [ref=f4e213] [cursor=pointer]
+  - region "Symfony Web Debug Toolbar" [ref=f4e214]:
+    - generic [ref=f4e217]:
+      - link "200 @ admin_content_page_edit" [ref=f4e219] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1ff6a6?panel=request
+        - generic [ref=f4e220]:
+          - generic [ref=f4e221]: "200"
+          - generic [ref=f4e222]: "@"
+          - generic [ref=f4e223]: admin_content_page_edit
+      - link "113 ms" [ref=f4e225] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1ff6a6?panel=time
+        - generic [ref=f4e226]:
+          - generic [ref=f4e227]: "113"
+          - generic [ref=f4e228]: ms
+      - link "10.0 MiB" [ref=f4e230] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1ff6a6?panel=time
+        - generic [ref=f4e231]:
+          - generic [ref=f4e232]: "10.0"
+          - generic [ref=f4e233]: MiB
+      - link "Cache 1" [ref=f4e235] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1ff6a6?panel=form
+        - generic [ref=f4e236]:
+          - img "Cache" [ref=f4e237]
+          - generic [ref=f4e243]: "1"
+      - link "Logger 499" [ref=f4e245] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1ff6a6?panel=logger
+        - generic [ref=f4e246]:
+          - img "Logger" [ref=f4e247]
+          - generic [ref=f4e251]: "499"
+      - link "Cache 5 in 0.14 ms" [ref=f4e253] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1ff6a6?panel=cache
+        - generic [ref=f4e254]:
+          - img "Cache" [ref=f4e255]
+          - generic [ref=f4e260]: "5"
+          - generic [ref=f4e261]: in 0.14 ms
+      - link "2" [ref=f4e263] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1ff6a6?panel=translation
+      - link "Security admin" [ref=f4e272] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1ff6a6?panel=security
+        - generic [ref=f4e273]:
+          - img "Security" [ref=f4e274]
+          - generic [ref=f4e278]: admin
+      - link "Twig 7 ms" [ref=f4e280] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1ff6a6?panel=twig
+        - generic [ref=f4e281]:
+          - img "Twig" [ref=f4e282]
+          - generic [ref=f4e286]: "7"
+          - generic [ref=f4e287]: ms
+      - link "13 in 3.08 ms" [ref=f4e289] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1ff6a6?panel=db
+        - generic [ref=f4e290]:
+          - generic [ref=f4e296]: "13"
+          - generic [ref=f4e297]: in 3.08 ms
+      - link "22" [ref=f4e299] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1ff6a6?panel=doctrine_migrations
+      - link "Symfony 7.4.13" [ref=f4e306] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/1ff6a6?panel=config
+        - generic [ref=f4e307]:
+          - img "Symfony" [ref=f4e309]
+          - generic [ref=f4e311]: 7.4.13
+      - generic [ref=f4e313]:
+        - img "eccube_logo_basic" [ref=f4e314]
+        - generic [ref=f4e319]: 4.3.1-p1
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f4e320] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f4e321]

--- a/.playwright-mcp/page-2026-08-03T05-26-22-467Z.yml
+++ b/.playwright-mcp/page-2026-08-03T05-26-22-467Z.yml
@@ -1,0 +1,185 @@
+- generic [active] [ref=f5e1]:
+  - banner [ref=f5e2]:
+    - generic [ref=f5e3]:
+      - heading [level=1] [ref=f5e5]
+      - text: 
+      - link "EC-CUBE SHOP" [ref=f5e7] [cursor=pointer]:
+        - /url: http://localhost:8080/
+        - text: EC-CUBE SHOP
+        - generic [ref=f5e8]: 
+      - generic [ref=f5e9] [cursor=pointer]:
+        - generic [ref=f5e10]: 
+        - text: 管理者 様
+        - generic [ref=f5e11]: 
+  - generic [ref=f5e12]:
+    - navigation [ref=f5e14]:
+      - list [ref=f5e15]:
+        - listitem [ref=f5e16]:
+          - link "ホーム" [ref=f5e17] [cursor=pointer]:
+            - /url: http://localhost:8080/admin/
+            - generic [ref=f5e18]: 
+            - text: ホーム
+        - listitem [ref=f5e19]:
+          - link "商品管理 " [ref=f5e20] [cursor=pointer]:
+            - /url: "#nav-product"
+            - generic [ref=f5e21]: 
+            - text: 商品管理 
+        - listitem [ref=f5e22]:
+          - link "受注管理 " [expanded] [ref=f5e23] [cursor=pointer]:
+            - /url: "#nav-order"
+            - generic [ref=f5e24]: 
+            - text: 受注管理 
+          - list [ref=f5e25]:
+            - listitem [ref=f5e26]:
+              - link "受注一覧" [ref=f5e27] [cursor=pointer]:
+                - /url: http://localhost:8080/admin/order
+            - listitem [ref=f5e28]:
+              - link "受注登録" [ref=f5e29] [cursor=pointer]:
+                - /url: http://localhost:8080/admin/order/new
+            - listitem [ref=f5e30]:
+              - link "出荷CSV登録" [ref=f5e31] [cursor=pointer]:
+                - /url: http://localhost:8080/admin/order/shipping_csv_upload
+            - listitem [ref=f5e32]:
+              - link "クーポン" [ref=f5e33] [cursor=pointer]:
+                - /url: http://localhost:8080/admin/plugin/coupon
+        - listitem [ref=f5e34]:
+          - link "会員管理 " [ref=f5e35] [cursor=pointer]:
+            - /url: "#nav-customer"
+            - generic [ref=f5e36]: 
+            - text: 会員管理 
+        - listitem [ref=f5e37]:
+          - link "コンテンツ管理 " [ref=f5e38] [cursor=pointer]:
+            - /url: "#nav-content"
+            - generic [ref=f5e39]: 
+            - text: コンテンツ管理 
+        - listitem [ref=f5e40]:
+          - link "設定 " [ref=f5e41] [cursor=pointer]:
+            - /url: "#nav-setting"
+            - generic [ref=f5e42]: 
+            - text: 設定 
+          - text:  
+        - listitem [ref=f5e43]:
+          - link "オーナーズストア " [ref=f5e44] [cursor=pointer]:
+            - /url: "#nav-store"
+            - generic [ref=f5e45]: 
+            - text: オーナーズストア 
+          - text:  
+        - listitem [ref=f5e46]:
+          - link "情報 " [ref=f5e47] [cursor=pointer]:
+            - /url: "#others"
+            - generic [ref=f5e48]: 
+            - text: 情報 
+    - generic [ref=f5e49]:
+      - generic [ref=f5e51]:
+        - heading "クーポン管理" [level=2] [ref=f5e52]
+        - generic [ref=f5e53]: クーポン内容設定
+      - alert [ref=f5e54]:
+        - generic [ref=f5e55]: 
+        - text: デバッグモードが有効になっています。
+        - button "Close" [ref=f5e56] [cursor=pointer]
+      - form [ref=f5e57]:
+        - generic [ref=f5e58]:
+          - generic [ref=f5e60]:
+            - generic [ref=f5e61]:
+              - generic [ref=f5e62]: クーポン情報
+              - generic [ref=f5e63]:
+                - generic [ref=f5e64]:
+                  - generic [ref=f5e65]:
+                    - generic [ref=f5e66]: クーポンコード
+                    - generic [ref=f5e67]: 必須
+                  - textbox "クーポンコード" [ref=f5e69]: cgl6hokng944
+                - generic [ref=f5e70]:
+                  - generic [ref=f5e71]:
+                    - generic [ref=f5e72]: クーポン名
+                    - generic [ref=f5e73]: 必須
+                  - textbox "クーポン名" [ref=f5e75]
+                - generic [ref=f5e76]:
+                  - generic [ref=f5e77]:
+                    - generic [ref=f5e78]: 対象商品
+                    - generic [ref=f5e79]: 必須
+                  - generic [ref=f5e81]:
+                    - generic [ref=f5e82]:
+                      - radio "商品" [checked] [ref=f5e83]
+                      - generic [ref=f5e84]: 商品
+                    - generic [ref=f5e85]:
+                      - radio "カテゴリ" [ref=f5e86]
+                      - generic [ref=f5e87]: カテゴリ
+                    - generic [ref=f5e88]:
+                      - radio "全商品" [ref=f5e89]
+                      - generic [ref=f5e90]: 全商品
+                - generic [ref=f5e91]:
+                  - generic [ref=f5e92]:
+                    - generic [ref=f5e93]: 利用制限
+                    - generic [ref=f5e94]: 必須
+                  - generic [ref=f5e96]:
+                    - generic [ref=f5e97]:
+                      - radio "会員のみ" [ref=f5e98]
+                      - generic [ref=f5e99]: 会員のみ
+                    - generic [ref=f5e100]:
+                      - radio "なし" [checked] [ref=f5e101]
+                      - generic [ref=f5e102]: なし
+                - generic [ref=f5e103]:
+                  - generic [ref=f5e104]:
+                    - generic [ref=f5e105]: 値引き種別
+                    - generic [ref=f5e106]: 必須
+                  - generic [ref=f5e108]:
+                    - generic [ref=f5e109]:
+                      - radio "値引き額" [checked] [ref=f5e110]
+                      - generic [ref=f5e111]: 値引き額
+                    - generic [ref=f5e112]:
+                      - radio "値引率" [ref=f5e113]
+                      - generic [ref=f5e114]: 値引率
+                - generic [ref=f5e115]:
+                  - generic [ref=f5e116]: 値引き額(円)
+                  - generic [ref=f5e118]:
+                    - generic [ref=f5e119]:
+                      - generic [ref=f5e120]: ￥
+                      - textbox "値引き額(円)" [ref=f5e121]
+                    - text: 合計金額から設定金額を値引きします。
+                - generic [ref=f5e122]:
+                  - generic [ref=f5e123]: 値引率(％)
+                  - generic [ref=f5e125]:
+                    - spinbutton "値引率(％)" [disabled] [ref=f5e126]
+                    - text: 対象商品の合計金額から設定した率を値引きします。
+                - generic [ref=f5e127]:
+                  - generic [ref=f5e128]:
+                    - generic [ref=f5e129]: 発行枚数
+                    - generic [ref=f5e130]: 必須
+                  - spinbutton "発行枚数" [ref=f5e132]
+                - generic [ref=f5e133]:
+                  - generic [ref=f5e134]: 下限金額(円)
+                  - generic [ref=f5e136]:
+                    - generic [ref=f5e137]:
+                      - generic [ref=f5e138]: ￥
+                      - textbox "下限金額(円)" [ref=f5e139]
+                    - text: 対象商品の合計金額が、下限金額以上の場合にクーポンを利用できます。
+                - generic [ref=f5e140]:
+                  - generic [ref=f5e141]:
+                    - generic [ref=f5e142]: 有効期間
+                    - generic [ref=f5e143]: 必須
+                  - generic [ref=f5e145]:
+                    - textbox "有効期間" [ref=f5e147]
+                    - generic [ref=f5e148]: ～
+                    - textbox [ref=f5e150]
+            - generic [ref=f5e151]:
+              - generic [ref=f5e153]:
+                - generic [ref=f5e154]: 商品情報
+                - link "" [ref=f5e157] [cursor=pointer]:
+                  - /url: "#productArea"
+              - generic [ref=f5e159]: 商品の追加
+            - text: 
+          - generic [ref=f5e165]:
+            - link "戻る" [ref=f5e168] [cursor=pointer]:
+              - /url: http://localhost:8080/admin/plugin/coupon
+              - generic [ref=f5e169]: 
+              - text: 戻る
+            - button "登録する" [ref=f5e173] [cursor=pointer]
+  - region "Symfony Web Debug Toolbar" [ref=f5e174]:
+    - generic [ref=f5e177]:
+      - link "Symfony Loading…" [ref=f5e179] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/bf467d?panel=request
+        - generic [ref=f5e180]:
+          - img "Symfony" [ref=f5e181]
+          - generic [ref=f5e183]: Loading…
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f5e184] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f5e185]

--- a/.playwright-mcp/page-2026-08-03T05-27-30-540Z.yml
+++ b/.playwright-mcp/page-2026-08-03T05-27-30-540Z.yml
@@ -1,0 +1,142 @@
+- generic [active] [ref=f7e1]:
+  - generic [ref=f7e2]: デバッグモードが有効になっています。
+  - generic [ref=f7e6]:
+    - banner [ref=f7e7]:
+      - generic [ref=f7e8]:
+        - generic [ref=f7e9]:
+          - generic [ref=f7e11]:
+            - generic:
+              - combobox [ref=f7e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f7e16]:
+                - searchbox "キーワードを入力" [ref=f7e17]
+                - button [ref=f7e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f7e20]:
+          - generic [ref=f7e22]:
+            - link " 新規会員登録" [ref=f7e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f7e25]: 
+              - generic [ref=f7e26]: 新規会員登録
+            - link " お気に入り" [ref=f7e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f7e29]: 
+              - generic [ref=f7e30]: お気に入り
+            - link " ログイン" [ref=f7e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f7e33]: 
+              - generic [ref=f7e34]: ログイン
+          - generic [ref=f7e37] [cursor=pointer]:
+            - generic [ref=f7e38]:
+              - text: 
+              - generic [ref=f7e39]: "0"
+            - generic [ref=f7e40]: ￥0
+      - heading [level=1] [ref=f7e46]:
+        - link "EC-CUBE SHOP" [ref=f7e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f7e50]:
+        - listitem [ref=f7e51]:
+          - link "新入荷" [ref=f7e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f7e53]:
+          - link "ジェラート" [ref=f7e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f7e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f7e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f7e57]:
+          - link "アイスサンド" [ref=f7e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f7e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f7e61]:
+      - generic [ref=f7e62]:
+        - list [ref=f7e64]:
+          - listitem [ref=f7e65]:
+            - link "全て" [ref=f7e66] [cursor=pointer]:
+              - /url: http://localhost:8080/products/list
+        - generic [ref=f7e67]:
+          - generic [ref=f7e68]: 2件の商品が見つかりました
+          - generic [ref=f7e70]:
+            - combobox [ref=f7e71]:
+              - option "20件" [selected]
+              - option "40件"
+              - option "60件"
+            - combobox [ref=f7e72]:
+              - option "価格が低い順" [selected]
+              - option "価格が高い順"
+              - option "新着順"
+      - list [ref=f7e74]:
+        - listitem [ref=f7e75]:
+          - link [ref=f7e76] [cursor=pointer]:
+            - /url: http://localhost:8080/products/detail/2
+            - paragraph [ref=f7e77]:
+              - img "チェリーアイスサンド" [ref=f7e78]
+            - paragraph [ref=f7e79]: チェリーアイスサンド
+            - paragraph [ref=f7e80]: ￥3,080
+          - generic [ref=f7e83]:
+            - text: 数量
+            - spinbutton [ref=f7e84]: "1"
+          - button "カートに入れる" [ref=f7e86] [cursor=pointer]
+        - listitem [ref=f7e87]:
+          - link [ref=f7e88] [cursor=pointer]:
+            - /url: http://localhost:8080/products/detail/1
+            - paragraph [ref=f7e89]:
+              - img "彩のジェラートCUBE" [ref=f7e90]
+            - paragraph [ref=f7e91]: 彩のジェラートCUBE
+            - paragraph [ref=f7e92]: ￥5,500 ～ ￥121,000
+          - generic [ref=f7e94]:
+            - combobox [ref=f7e96]:
+              - option "選択してください" [selected]
+              - option "チョコ"
+              - option "抹茶"
+              - option "バニラ"
+            - combobox [ref=f7e98]:
+              - option "選択してください" [selected]
+            - generic [ref=f7e99]:
+              - text: 数量
+              - spinbutton [ref=f7e100]: "1"
+          - button "カートに入れる" [ref=f7e102] [cursor=pointer]
+    - contentinfo [ref=f7e103]:
+      - generic [ref=f7e105]:
+        - list [ref=f7e106]:
+          - listitem [ref=f7e107]:
+            - link "当サイトについて" [ref=f7e108] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f7e109]:
+            - link "プライバシーポリシー" [ref=f7e110] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f7e111]:
+            - link "特定商取引法に基づく表記" [ref=f7e112] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f7e113]:
+            - link "お問い合わせ" [ref=f7e114] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f7e115]:
+          - link "EC-CUBE SHOP" [ref=f7e117] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f7e118]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f7e119]:
+    - generic [ref=f7e122]:
+      - link "Symfony Loading…" [ref=f7e124] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/54194d?panel=request
+        - generic [ref=f7e125]:
+          - img "Symfony" [ref=f7e126]
+          - generic [ref=f7e128]: Loading…
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f7e129] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f7e130]

--- a/.playwright-mcp/page-2026-08-03T05-27-40-288Z.yml
+++ b/.playwright-mcp/page-2026-08-03T05-27-40-288Z.yml
@@ -1,0 +1,179 @@
+- generic [active] [ref=f8e1]:
+  - generic [ref=f8e2]: デバッグモードが有効になっています。
+  - generic [ref=f8e6]:
+    - banner [ref=f8e7]:
+      - generic [ref=f8e8]:
+        - generic [ref=f8e9]:
+          - generic [ref=f8e11]:
+            - generic:
+              - combobox [ref=f8e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f8e16]:
+                - searchbox "キーワードを入力" [ref=f8e17]
+                - button [ref=f8e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f8e20]:
+          - generic [ref=f8e22]:
+            - link " 新規会員登録" [ref=f8e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f8e25]: 
+              - generic [ref=f8e26]: 新規会員登録
+            - link " お気に入り" [ref=f8e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f8e29]: 
+              - generic [ref=f8e30]: お気に入り
+            - link " ログイン" [ref=f8e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f8e33]: 
+              - generic [ref=f8e34]: ログイン
+          - generic [ref=f8e37] [cursor=pointer]:
+            - generic [ref=f8e38]:
+              - text: 
+              - generic [ref=f8e39]: "0"
+            - generic [ref=f8e40]: ￥0
+      - heading [level=1] [ref=f8e46]:
+        - link "EC-CUBE SHOP" [ref=f8e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f8e50]:
+        - listitem [ref=f8e51]:
+          - link "新入荷" [ref=f8e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f8e53]:
+          - link "ジェラート" [ref=f8e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f8e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f8e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f8e57]:
+          - link "アイスサンド" [ref=f8e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f8e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f8e61]:
+      - generic [ref=f8e63]:
+        - img "チェリーアイスサンド" [ref=f8e75]
+        - generic [ref=f8e97]:
+          - heading "チェリーアイスサンド" [level=2] [ref=f8e99]
+          - list [ref=f8e100]
+          - text: 通常価格：￥3,300 税込
+          - generic [ref=f8e102]:
+            - generic [ref=f8e103]: ￥3,080
+            - text: 税込
+          - generic [ref=f8e104]: 商品コード： sand-01
+          - generic [ref=f8e105]:
+            - generic [ref=f8e106]: 関連カテゴリ
+            - list [ref=f8e107]:
+              - listitem [ref=f8e108]:
+                - link "新入荷" [ref=f8e109] [cursor=pointer]:
+                  - /url: http://localhost:8080/products/list?category_id=2
+              - listitem [ref=f8e110]:
+                - link "アイスサンド" [ref=f8e111] [cursor=pointer]:
+                  - /url: http://localhost:8080/products/list?category_id=5
+                - text: ">"
+                - link "フルーツ" [ref=f8e112] [cursor=pointer]:
+                  - /url: http://localhost:8080/products/list?category_id=6
+          - generic [ref=f8e113]:
+            - generic [ref=f8e115]:
+              - text: 数量
+              - spinbutton [ref=f8e116]: "1"
+            - button "カートに入れる" [ref=f8e118] [cursor=pointer]
+          - button "お気に入りに追加" [ref=f8e121] [cursor=pointer]
+          - generic [ref=f8e122]: チェリーアイスサンドは北海道産のチェリーのアイスをサクサクのクッキーでサンドしたスイーツです。 立方体なので大量に持ち運ぶときも便利です。 いまだけ、頑丈な箱つきです。
+    - contentinfo [ref=f8e123]:
+      - generic [ref=f8e125]:
+        - list [ref=f8e126]:
+          - listitem [ref=f8e127]:
+            - link "当サイトについて" [ref=f8e128] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f8e129]:
+            - link "プライバシーポリシー" [ref=f8e130] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f8e131]:
+            - link "特定商取引法に基づく表記" [ref=f8e132] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f8e133]:
+            - link "お問い合わせ" [ref=f8e134] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f8e135]:
+          - link "EC-CUBE SHOP" [ref=f8e137] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f8e138]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f8e139]:
+    - generic [ref=f8e142]:
+      - link "200 @ product_detail" [ref=f8e144] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=request
+        - generic [ref=f8e145]:
+          - generic [ref=f8e146]: "200"
+          - generic [ref=f8e147]: "@"
+          - generic [ref=f8e148]: product_detail
+      - link "149 ms" [ref=f8e150] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=time
+        - generic [ref=f8e151]:
+          - generic [ref=f8e152]: "149"
+          - generic [ref=f8e153]: ms
+      - link "12.0 MiB" [ref=f8e155] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=time
+        - generic [ref=f8e156]:
+          - generic [ref=f8e157]: "12.0"
+          - generic [ref=f8e158]: MiB
+      - link "Cache 1" [ref=f8e160] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=form
+        - generic [ref=f8e161]:
+          - img "Cache" [ref=f8e162]
+          - generic [ref=f8e168]: "1"
+      - link "Logger 483" [ref=f8e170] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=logger
+        - generic [ref=f8e171]:
+          - img "Logger" [ref=f8e172]
+          - generic [ref=f8e176]: "483"
+      - link "Cache 24 in 0.35 ms" [ref=f8e178] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=cache
+        - generic [ref=f8e179]:
+          - img "Cache" [ref=f8e180]
+          - generic [ref=f8e185]: "24"
+          - generic [ref=f8e186]: in 0.35 ms
+      - link "30" [ref=f8e188] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=translation
+      - link "Security n/a" [ref=f8e197] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=security
+        - generic [ref=f8e198]:
+          - img "Security" [ref=f8e199]
+          - generic [ref=f8e203]: n/a
+      - link "Twig 44 ms" [ref=f8e205] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=twig
+        - generic [ref=f8e206]:
+          - img "Twig" [ref=f8e207]
+          - generic [ref=f8e211]: "44"
+          - generic [ref=f8e212]: ms
+      - link "14 in 3.09 ms" [ref=f8e214] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=db
+        - generic [ref=f8e215]:
+          - generic [ref=f8e221]: "14"
+          - generic [ref=f8e222]: in 3.09 ms
+      - link "22" [ref=f8e224] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=doctrine_migrations
+      - link "Symfony 7.4.13" [ref=f8e231] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=config
+        - generic [ref=f8e232]:
+          - img "Symfony" [ref=f8e234]
+          - generic [ref=f8e236]: 7.4.13
+      - generic [ref=f8e238]:
+        - img "eccube_logo_basic" [ref=f8e239]
+        - generic [ref=f8e244]: 4.3.1-p1
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f8e245] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f8e246]

--- a/.playwright-mcp/page-2026-08-03T05-27-54-278Z.yml
+++ b/.playwright-mcp/page-2026-08-03T05-27-54-278Z.yml
@@ -1,0 +1,186 @@
+- generic [active] [ref=f8e1]:
+  - generic [ref=f8e2]: デバッグモードが有効になっています。
+  - generic [ref=f8e6]:
+    - banner [ref=f8e7]:
+      - generic [ref=f8e8]:
+        - generic [ref=f8e9]:
+          - generic [ref=f8e11]:
+            - generic:
+              - combobox [ref=f8e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f8e16]:
+                - searchbox "キーワードを入力" [ref=f8e17]
+                - button [ref=f8e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f8e20]:
+          - generic [ref=f8e22]:
+            - link " 新規会員登録" [ref=f8e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f8e25]: 
+              - generic [ref=f8e26]: 新規会員登録
+            - link " お気に入り" [ref=f8e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f8e29]: 
+              - generic [ref=f8e30]: お気に入り
+            - link " ログイン" [ref=f8e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f8e33]: 
+              - generic [ref=f8e34]: ログイン
+          - generic [ref=f8e252] [cursor=pointer]:
+            - generic [ref=f8e253]:
+              - text: 
+              - generic [ref=f8e254]: "2"
+            - generic [ref=f8e255]: ￥6,160
+      - heading [level=1] [ref=f8e46]:
+        - link "EC-CUBE SHOP" [ref=f8e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f8e50]:
+        - listitem [ref=f8e51]:
+          - link "新入荷" [ref=f8e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f8e53]:
+          - link "ジェラート" [ref=f8e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f8e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f8e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f8e57]:
+          - link "アイスサンド" [ref=f8e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f8e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f8e61]:
+      - generic [ref=f8e63]:
+        - img "チェリーアイスサンド" [ref=f8e75]
+        - generic [ref=f8e97]:
+          - heading "チェリーアイスサンド" [level=2] [ref=f8e99]
+          - list [ref=f8e100]
+          - text: 通常価格：￥3,300 税込
+          - generic [ref=f8e102]:
+            - generic [ref=f8e103]: ￥3,080
+            - text: 税込
+          - generic [ref=f8e104]: 商品コード： sand-01
+          - generic [ref=f8e105]:
+            - generic [ref=f8e106]: 関連カテゴリ
+            - list [ref=f8e107]:
+              - listitem [ref=f8e108]:
+                - link "新入荷" [ref=f8e109] [cursor=pointer]:
+                  - /url: http://localhost:8080/products/list?category_id=2
+              - listitem [ref=f8e110]:
+                - link "アイスサンド" [ref=f8e111] [cursor=pointer]:
+                  - /url: http://localhost:8080/products/list?category_id=5
+                - text: ">"
+                - link "フルーツ" [ref=f8e112] [cursor=pointer]:
+                  - /url: http://localhost:8080/products/list?category_id=6
+          - generic [ref=f8e113]:
+            - generic [ref=f8e115]:
+              - text: 数量
+              - spinbutton [ref=f8e116]: "2"
+            - button "カートに入れる" [ref=f8e118] [cursor=pointer]
+          - generic [ref=f8e259]:
+            - generic [ref=f8e262]: カートに追加しました。
+            - generic [ref=f8e264]:
+              - generic [ref=f8e265] [cursor=pointer]: お買い物を続ける
+              - link "カートへ進む" [ref=f8e266] [cursor=pointer]:
+                - /url: http://localhost:8080/cart
+          - button "お気に入りに追加" [ref=f8e121] [cursor=pointer]
+          - generic [ref=f8e122]: チェリーアイスサンドは北海道産のチェリーのアイスをサクサクのクッキーでサンドしたスイーツです。 立方体なので大量に持ち運ぶときも便利です。 いまだけ、頑丈な箱つきです。
+    - contentinfo [ref=f8e123]:
+      - generic [ref=f8e125]:
+        - list [ref=f8e126]:
+          - listitem [ref=f8e127]:
+            - link "当サイトについて" [ref=f8e128] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f8e129]:
+            - link "プライバシーポリシー" [ref=f8e130] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f8e131]:
+            - link "特定商取引法に基づく表記" [ref=f8e132] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f8e133]:
+            - link "お問い合わせ" [ref=f8e134] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f8e135]:
+          - link "EC-CUBE SHOP" [ref=f8e137] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f8e138]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f8e139]:
+    - generic [ref=f8e142]:
+      - link "200 @ product_detail" [ref=f8e144] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=request
+        - generic [ref=f8e145]:
+          - generic [ref=f8e146]: "200"
+          - generic [ref=f8e147]: "@"
+          - generic [ref=f8e148]: product_detail
+      - link "149 ms" [ref=f8e150] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=time
+        - generic [ref=f8e151]:
+          - generic [ref=f8e152]: "149"
+          - generic [ref=f8e153]: ms
+      - link "12.0 MiB" [ref=f8e155] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=time
+        - generic [ref=f8e156]:
+          - generic [ref=f8e157]: "12.0"
+          - generic [ref=f8e158]: MiB
+      - generic [ref=f8e267]: "2"
+      - link "Cache 1" [ref=f8e160] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=form
+        - generic [ref=f8e161]:
+          - img "Cache" [ref=f8e162]
+          - generic [ref=f8e168]: "1"
+      - link "Logger 483" [ref=f8e170] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=logger
+        - generic [ref=f8e171]:
+          - img "Logger" [ref=f8e172]
+          - generic [ref=f8e176]: "483"
+      - link "Cache 24 in 0.35 ms" [ref=f8e178] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=cache
+        - generic [ref=f8e179]:
+          - img "Cache" [ref=f8e180]
+          - generic [ref=f8e185]: "24"
+          - generic [ref=f8e186]: in 0.35 ms
+      - link "30" [ref=f8e188] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=translation
+      - link "Security n/a" [ref=f8e197] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=security
+        - generic [ref=f8e198]:
+          - img "Security" [ref=f8e199]
+          - generic [ref=f8e203]: n/a
+      - link "Twig 44 ms" [ref=f8e205] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=twig
+        - generic [ref=f8e206]:
+          - img "Twig" [ref=f8e207]
+          - generic [ref=f8e211]: "44"
+          - generic [ref=f8e212]: ms
+      - link "14 in 3.09 ms" [ref=f8e214] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=db
+        - generic [ref=f8e215]:
+          - generic [ref=f8e221]: "14"
+          - generic [ref=f8e222]: in 3.09 ms
+      - link "22" [ref=f8e224] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=doctrine_migrations
+      - link "Symfony 7.4.13" [ref=f8e231] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/ffe396?panel=config
+        - generic [ref=f8e232]:
+          - img "Symfony" [ref=f8e234]
+          - generic [ref=f8e236]: 7.4.13
+      - generic [ref=f8e238]:
+        - img "eccube_logo_basic" [ref=f8e239]
+        - generic [ref=f8e244]: 4.3.1-p1
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f8e245] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f8e246]

--- a/.playwright-mcp/page-2026-08-03T05-28-00-046Z.yml
+++ b/.playwright-mcp/page-2026-08-03T05-28-00-046Z.yml
@@ -1,0 +1,209 @@
+- generic [active] [ref=f9e1]:
+  - generic [ref=f9e2]: デバッグモードが有効になっています。
+  - generic [ref=f9e6]:
+    - banner [ref=f9e7]:
+      - generic [ref=f9e8]:
+        - generic [ref=f9e9]:
+          - generic [ref=f9e11]:
+            - generic:
+              - combobox [ref=f9e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f9e16]:
+                - searchbox "キーワードを入力" [ref=f9e17]
+                - button [ref=f9e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f9e20]:
+          - generic [ref=f9e22]:
+            - link " 新規会員登録" [ref=f9e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f9e25]: 
+              - generic [ref=f9e26]: 新規会員登録
+            - link " お気に入り" [ref=f9e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f9e29]: 
+              - generic [ref=f9e30]: お気に入り
+            - link " ログイン" [ref=f9e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f9e33]: 
+              - generic [ref=f9e34]: ログイン
+          - generic [ref=f9e37] [cursor=pointer]:
+            - generic [ref=f9e38]:
+              - text: 
+              - generic [ref=f9e39]: "2"
+            - generic [ref=f9e40]: ￥6,160
+      - heading [level=1] [ref=f9e46]:
+        - link "EC-CUBE SHOP" [ref=f9e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f9e50]:
+        - listitem [ref=f9e51]:
+          - link "新入荷" [ref=f9e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f9e53]:
+          - link "ジェラート" [ref=f9e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f9e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f9e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f9e57]:
+          - link "アイスサンド" [ref=f9e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f9e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f9e61]:
+      - heading "ショッピングカート" [level=1] [ref=f9e64]
+      - generic [ref=f9e65]:
+        - list [ref=f9e67]:
+          - listitem [ref=f9e68]:
+            - generic [ref=f9e69]: "1"
+            - generic [ref=f9e70]: カートの商品
+          - listitem [ref=f9e71]:
+            - generic [ref=f9e72]: "2"
+            - generic [ref=f9e73]: お客様情報
+          - listitem [ref=f9e74]:
+            - generic [ref=f9e75]: "3"
+            - generic [ref=f9e76]: ご注文手続き
+          - listitem [ref=f9e77]:
+            - generic [ref=f9e78]: "4"
+            - generic [ref=f9e79]: ご注文内容確認
+          - listitem [ref=f9e80]:
+            - generic [ref=f9e81]: "5"
+            - generic [ref=f9e82]: 完了
+        - paragraph [ref=f9e84]:
+          - text: 商品の合計金額は「
+          - strong [ref=f9e85]: ￥6,160
+          - text: 」です。
+        - generic [ref=f9e86]:
+          - generic [ref=f9e88]:
+            - list [ref=f9e89]:
+              - listitem [ref=f9e90]: 削除
+              - listitem [ref=f9e91]: 商品内容
+              - listitem [ref=f9e92]: 数量
+              - listitem [ref=f9e93]: 小計
+            - list [ref=f9e94]:
+              - listitem [ref=f9e95]:
+                - link [ref=f9e96] [cursor=pointer]:
+                  - /url: http://localhost:8080/cart/remove/11
+                  - img "delete" [ref=f9e97]
+              - listitem [ref=f9e98]:
+                - link [ref=f9e100] [cursor=pointer]:
+                  - /url: http://localhost:8080/products/detail/2
+                  - img "チェリーアイスサンド" [ref=f9e101]
+                - generic [ref=f9e102]:
+                  - link "チェリーアイスサンド" [ref=f9e104] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/detail/2
+                  - generic [ref=f9e105]: ￥3,080
+              - listitem [ref=f9e106]:
+                - generic [ref=f9e107]: "2"
+                - generic [ref=f9e108]:
+                  - link [ref=f9e109] [cursor=pointer]:
+                    - /url: http://localhost:8080/cart/down/11
+                    - img "reduce" [ref=f9e110]
+                  - link [ref=f9e111] [cursor=pointer]:
+                    - /url: http://localhost:8080/cart/up/11
+                    - img "increase" [ref=f9e112]
+              - listitem [ref=f9e113]:
+                - generic [ref=f9e114]: ￥6,160
+          - generic [ref=f9e115]:
+            - generic [ref=f9e116]: 合計：￥6,160
+            - link "レジに進む" [ref=f9e117] [cursor=pointer]:
+              - /url: /cart/buystep/jgkKfr1Ok6IWLjXtoqJd5F4Ysvv9FCFF_1
+            - link "お買い物を続ける" [ref=f9e118] [cursor=pointer]:
+              - /url: /
+    - contentinfo [ref=f9e119]:
+      - generic [ref=f9e121]:
+        - list [ref=f9e122]:
+          - listitem [ref=f9e123]:
+            - link "当サイトについて" [ref=f9e124] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f9e125]:
+            - link "プライバシーポリシー" [ref=f9e126] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f9e127]:
+            - link "特定商取引法に基づく表記" [ref=f9e128] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f9e129]:
+            - link "お問い合わせ" [ref=f9e130] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f9e131]:
+          - link "EC-CUBE SHOP" [ref=f9e133] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f9e134]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f9e135]:
+    - generic [ref=f9e138]:
+      - link "200 @ cart" [ref=f9e140] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b59bc8?panel=request
+        - generic [ref=f9e141]:
+          - generic [ref=f9e142]: "200"
+          - generic [ref=f9e143]: "@"
+          - generic [ref=f9e144]: cart
+      - link "136 ms" [ref=f9e146] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b59bc8?panel=time
+        - generic [ref=f9e147]:
+          - generic [ref=f9e148]: "136"
+          - generic [ref=f9e149]: ms
+      - link "12.0 MiB" [ref=f9e151] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b59bc8?panel=time
+        - generic [ref=f9e152]:
+          - generic [ref=f9e153]: "12.0"
+          - generic [ref=f9e154]: MiB
+      - link "Cache 1" [ref=f9e156] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b59bc8?panel=form
+        - generic [ref=f9e157]:
+          - img "Cache" [ref=f9e158]
+          - generic [ref=f9e164]: "1"
+      - link "Logger 480" [ref=f9e166] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b59bc8?panel=logger
+        - generic [ref=f9e167]:
+          - img "Logger" [ref=f9e168]
+          - generic [ref=f9e172]: "480"
+      - link "Cache 20 in 0.27 ms" [ref=f9e174] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b59bc8?panel=cache
+        - generic [ref=f9e175]:
+          - img "Cache" [ref=f9e176]
+          - generic [ref=f9e181]: "20"
+          - generic [ref=f9e182]: in 0.27 ms
+      - link "36" [ref=f9e184] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b59bc8?panel=translation
+      - link "Security n/a" [ref=f9e193] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b59bc8?panel=security
+        - generic [ref=f9e194]:
+          - img "Security" [ref=f9e195]
+          - generic [ref=f9e199]: n/a
+      - link "Twig 34 ms" [ref=f9e201] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b59bc8?panel=twig
+        - generic [ref=f9e202]:
+          - img "Twig" [ref=f9e203]
+          - generic [ref=f9e207]: "34"
+          - generic [ref=f9e208]: ms
+      - link "21 in 3.56 ms" [ref=f9e210] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b59bc8?panel=db
+        - generic [ref=f9e211]:
+          - generic [ref=f9e217]: "21"
+          - generic [ref=f9e218]: in 3.56 ms
+      - link "22" [ref=f9e220] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b59bc8?panel=doctrine_migrations
+      - link "Symfony 7.4.13" [ref=f9e227] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b59bc8?panel=config
+        - generic [ref=f9e228]:
+          - img "Symfony" [ref=f9e230]
+          - generic [ref=f9e232]: 7.4.13
+      - generic [ref=f9e234]:
+        - img "eccube_logo_basic" [ref=f9e235]
+        - generic [ref=f9e240]: 4.3.1-p1
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f9e241] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f9e242]

--- a/.playwright-mcp/page-2026-08-03T05-28-11-982Z.yml
+++ b/.playwright-mcp/page-2026-08-03T05-28-11-982Z.yml
@@ -1,0 +1,172 @@
+- generic [ref=f10e1]:
+  - generic [ref=f10e2]: デバッグモードが有効になっています。
+  - generic [ref=f10e6]:
+    - banner [ref=f10e7]:
+      - generic [ref=f10e8]:
+        - generic [ref=f10e9]:
+          - generic [ref=f10e11]:
+            - generic:
+              - combobox [ref=f10e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f10e16]:
+                - searchbox "キーワードを入力" [ref=f10e17]
+                - button [ref=f10e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f10e20]:
+          - generic [ref=f10e22]:
+            - link " 新規会員登録" [ref=f10e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f10e25]: 
+              - generic [ref=f10e26]: 新規会員登録
+            - link " お気に入り" [ref=f10e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f10e29]: 
+              - generic [ref=f10e30]: お気に入り
+            - link " ログイン" [ref=f10e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f10e33]: 
+              - generic [ref=f10e34]: ログイン
+          - generic [ref=f10e37] [cursor=pointer]:
+            - generic [ref=f10e38]:
+              - text: 
+              - generic [ref=f10e39]: "2"
+            - generic [ref=f10e40]: ￥6,160
+      - heading [level=1] [ref=f10e46]:
+        - link "EC-CUBE SHOP" [ref=f10e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f10e50]:
+        - listitem [ref=f10e51]:
+          - link "新入荷" [ref=f10e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f10e53]:
+          - link "ジェラート" [ref=f10e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f10e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f10e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f10e57]:
+          - link "アイスサンド" [ref=f10e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f10e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f10e61]:
+      - heading "ログイン" [level=1] [ref=f10e64]
+      - generic [ref=f10e66]:
+        - generic [ref=f10e69]:
+          - generic [ref=f10e72]:
+            - generic [ref=f10e73]:
+              - textbox "メールアドレス" [active] [ref=f10e74]: admin
+              - textbox "パスワード" [ref=f10e75]
+            - generic [ref=f10e78]:
+              - checkbox "次回から自動的にログインする" [ref=f10e79]
+              - generic [ref=f10e80]: 次回から自動的にログインする
+          - generic [ref=f10e81]:
+            - button "ログイン" [ref=f10e84] [cursor=pointer]
+            - generic [ref=f10e85]:
+              - link "ログイン情報をお忘れですか？" [ref=f10e87] [cursor=pointer]:
+                - /url: http://localhost:8080/forgot
+              - link "新規会員登録" [ref=f10e89] [cursor=pointer]:
+                - /url: http://localhost:8080/entry
+        - generic [ref=f10e92]:
+          - paragraph [ref=f10e93]: 会員登録をせずに購入手続きをされたい方は、下記よりお進みください。
+          - link "ゲスト購入" [ref=f10e95] [cursor=pointer]:
+            - /url: http://localhost:8080/shopping/nonmember
+    - contentinfo [ref=f10e96]:
+      - generic [ref=f10e98]:
+        - list [ref=f10e99]:
+          - listitem [ref=f10e100]:
+            - link "当サイトについて" [ref=f10e101] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f10e102]:
+            - link "プライバシーポリシー" [ref=f10e103] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f10e104]:
+            - link "特定商取引法に基づく表記" [ref=f10e105] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f10e106]:
+            - link "お問い合わせ" [ref=f10e107] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f10e108]:
+          - link "EC-CUBE SHOP" [ref=f10e110] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f10e111]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f10e112]:
+    - generic [ref=f10e115]:
+      - link "200 Redirect @ shopping_login" [ref=f10e117] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6e31be?panel=request
+        - generic [ref=f10e118]:
+          - generic [ref=f10e119]: "200"
+          - img "Redirect" [ref=f10e121]
+          - generic [ref=f10e124]: "@"
+          - generic [ref=f10e125]: shopping_login
+      - link "100 ms" [ref=f10e127] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6e31be?panel=time
+        - generic [ref=f10e128]:
+          - generic [ref=f10e129]: "100"
+          - generic [ref=f10e130]: ms
+      - link "12.0 MiB" [ref=f10e132] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6e31be?panel=time
+        - generic [ref=f10e133]:
+          - generic [ref=f10e134]: "12.0"
+          - generic [ref=f10e135]: MiB
+      - link "Cache 1" [ref=f10e137] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6e31be?panel=form
+        - generic [ref=f10e138]:
+          - img "Cache" [ref=f10e139]
+          - generic [ref=f10e145]: "1"
+      - link "Logger 479" [ref=f10e147] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6e31be?panel=logger
+        - generic [ref=f10e148]:
+          - img "Logger" [ref=f10e149]
+          - generic [ref=f10e153]: "479"
+      - link "Cache 20 in 0.23 ms" [ref=f10e155] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6e31be?panel=cache
+        - generic [ref=f10e156]:
+          - img "Cache" [ref=f10e157]
+          - generic [ref=f10e162]: "20"
+          - generic [ref=f10e163]: in 0.23 ms
+      - link "3" [ref=f10e165] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6e31be?panel=translation
+      - link "Security n/a" [ref=f10e174] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6e31be?panel=security
+        - generic [ref=f10e175]:
+          - img "Security" [ref=f10e176]
+          - generic [ref=f10e180]: n/a
+      - link "Twig 35 ms" [ref=f10e182] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6e31be?panel=twig
+        - generic [ref=f10e183]:
+          - img "Twig" [ref=f10e184]
+          - generic [ref=f10e188]: "35"
+          - generic [ref=f10e189]: ms
+      - link "19 in 2.43 ms" [ref=f10e191] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6e31be?panel=db
+        - generic [ref=f10e192]:
+          - generic [ref=f10e198]: "19"
+          - generic [ref=f10e199]: in 2.43 ms
+      - link "22" [ref=f10e201] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6e31be?panel=doctrine_migrations
+      - link "Symfony 7.4.13" [ref=f10e208] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6e31be?panel=config
+        - generic [ref=f10e209]:
+          - img "Symfony" [ref=f10e211]
+          - generic [ref=f10e213]: 7.4.13
+      - generic [ref=f10e215]:
+        - img "eccube_logo_basic" [ref=f10e216]
+        - generic [ref=f10e221]: 4.3.1-p1
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f10e222] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f10e223]

--- a/.playwright-mcp/page-2026-08-03T05-28-32-923Z.yml
+++ b/.playwright-mcp/page-2026-08-03T05-28-32-923Z.yml
@@ -1,0 +1,215 @@
+- generic [active] [ref=f11e1]:
+  - generic [ref=f11e2]: デバッグモードが有効になっています。
+  - generic [ref=f11e6]:
+    - banner [ref=f11e7]:
+      - generic [ref=f11e8]:
+        - generic [ref=f11e9]:
+          - generic [ref=f11e11]:
+            - generic:
+              - combobox [ref=f11e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f11e16]:
+                - searchbox "キーワードを入力" [ref=f11e17]
+                - button [ref=f11e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f11e20]:
+          - generic [ref=f11e22]:
+            - link " 新規会員登録" [ref=f11e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f11e25]: 
+              - generic [ref=f11e26]: 新規会員登録
+            - link " お気に入り" [ref=f11e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f11e29]: 
+              - generic [ref=f11e30]: お気に入り
+            - link " ログイン" [ref=f11e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f11e33]: 
+              - generic [ref=f11e34]: ログイン
+          - generic [ref=f11e37] [cursor=pointer]:
+            - generic [ref=f11e38]:
+              - text: 
+              - generic [ref=f11e39]: "2"
+            - generic [ref=f11e40]: ￥6,160
+      - heading [level=1] [ref=f11e46]:
+        - link "EC-CUBE SHOP" [ref=f11e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f11e50]:
+        - listitem [ref=f11e51]:
+          - link "新入荷" [ref=f11e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f11e53]:
+          - link "ジェラート" [ref=f11e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f11e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f11e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f11e57]:
+          - link "アイスサンド" [ref=f11e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f11e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f11e61]:
+      - generic [ref=f11e62]:
+        - heading "お客様情報の入力" [level=1] [ref=f11e64]
+        - list [ref=f11e67]:
+          - listitem [ref=f11e68]:
+            - generic [ref=f11e69]: "1"
+            - generic [ref=f11e70]: カートの商品
+          - listitem [ref=f11e71]:
+            - generic [ref=f11e72]: "2"
+            - generic [ref=f11e73]: お客様情報
+          - listitem [ref=f11e74]:
+            - generic [ref=f11e75]: "3"
+            - generic [ref=f11e76]: ご注文手続き
+          - listitem [ref=f11e77]:
+            - generic [ref=f11e78]: "4"
+            - generic [ref=f11e79]: ご注文内容確認
+          - listitem [ref=f11e80]:
+            - generic [ref=f11e81]: "5"
+            - generic [ref=f11e82]: 完了
+        - generic [ref=f11e85]:
+          - generic [ref=f11e86]:
+            - generic [ref=f11e87]:
+              - term [ref=f11e88]:
+                - generic [ref=f11e89]: お名前
+                - generic [ref=f11e90]: 必須
+              - definition [ref=f11e91]:
+                - generic [ref=f11e92]:
+                  - textbox "姓" [ref=f11e93]
+                  - textbox "名" [ref=f11e94]
+            - generic [ref=f11e95]:
+              - term [ref=f11e96]:
+                - generic [ref=f11e97]: お名前(カナ)
+                - generic [ref=f11e98]: 必須
+              - definition [ref=f11e99]:
+                - generic [ref=f11e100]:
+                  - textbox "セイ" [ref=f11e101]
+                  - textbox "メイ" [ref=f11e102]
+            - generic [ref=f11e103]:
+              - term [ref=f11e104]:
+                - generic [ref=f11e105]: 会社名
+              - definition [ref=f11e106]:
+                - textbox "会社名" [ref=f11e108]
+            - generic [ref=f11e109]:
+              - term [ref=f11e110]:
+                - generic [ref=f11e111]: 住所
+                - generic [ref=f11e112]: 必須
+              - definition [ref=f11e113]:
+                - generic [ref=f11e114]:
+                  - generic [ref=f11e115]: 〒
+                  - textbox "例：5300001" [ref=f11e116]
+                  - link "郵便番号検索" [ref=f11e120] [cursor=pointer]:
+                    - /url: https://www.post.japanpost.jp/zipcode/
+                - combobox [ref=f11e122]:
+                  - option "都道府県を選択" [selected]
+                  - option "北海道"
+                  - option "青森県"
+                  - option "岩手県"
+                  - option "宮城県"
+                  - option "秋田県"
+                  - option "山形県"
+                  - option "福島県"
+                  - option "茨城県"
+                  - option "栃木県"
+                  - option "群馬県"
+                  - option "埼玉県"
+                  - option "千葉県"
+                  - option "東京都"
+                  - option "神奈川県"
+                  - option "新潟県"
+                  - option "富山県"
+                  - option "石川県"
+                  - option "福井県"
+                  - option "山梨県"
+                  - option "長野県"
+                  - option "岐阜県"
+                  - option "静岡県"
+                  - option "愛知県"
+                  - option "三重県"
+                  - option "滋賀県"
+                  - option "京都府"
+                  - option "大阪府"
+                  - option "兵庫県"
+                  - option "奈良県"
+                  - option "和歌山県"
+                  - option "鳥取県"
+                  - option "島根県"
+                  - option "岡山県"
+                  - option "広島県"
+                  - option "山口県"
+                  - option "徳島県"
+                  - option "香川県"
+                  - option "愛媛県"
+                  - option "高知県"
+                  - option "福岡県"
+                  - option "佐賀県"
+                  - option "長崎県"
+                  - option "熊本県"
+                  - option "大分県"
+                  - option "宮崎県"
+                  - option "鹿児島県"
+                  - option "沖縄県"
+                - textbox "市区町村名(例：大阪市北区)" [ref=f11e124]
+                - textbox "番地・ビル名(例：西梅田1丁目6-8)" [ref=f11e126]
+            - generic [ref=f11e127]:
+              - term [ref=f11e128]:
+                - generic [ref=f11e129]: 電話番号
+                - generic [ref=f11e130]: 必須
+              - definition [ref=f11e131]:
+                - textbox "電話番号" [ref=f11e133]:
+                  - /placeholder: 例：11122223333
+            - generic [ref=f11e134]:
+              - term [ref=f11e135]:
+                - generic [ref=f11e136]: メールアドレス
+                - generic [ref=f11e137]: 必須
+              - definition [ref=f11e138]:
+                - textbox "例：ec-cube@example.com" [ref=f11e140]
+                - textbox "確認のためもう一度入力してください" [ref=f11e142]
+          - generic [ref=f11e145]:
+            - button "次へ" [ref=f11e146] [cursor=pointer]
+            - link "戻る" [ref=f11e147] [cursor=pointer]:
+              - /url: http://localhost:8080/cart
+    - contentinfo [ref=f11e148]:
+      - generic [ref=f11e150]:
+        - list [ref=f11e151]:
+          - listitem [ref=f11e152]:
+            - link "当サイトについて" [ref=f11e153] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f11e154]:
+            - link "プライバシーポリシー" [ref=f11e155] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f11e156]:
+            - link "特定商取引法に基づく表記" [ref=f11e157] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f11e158]:
+            - link "お問い合わせ" [ref=f11e159] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f11e160]:
+          - link "EC-CUBE SHOP" [ref=f11e162] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f11e163]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f11e164]:
+    - generic [ref=f11e167]:
+      - link "Symfony Loading…" [ref=f11e169] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/bbaae0?panel=request
+        - generic [ref=f11e170]:
+          - img "Symfony" [ref=f11e171]
+          - generic [ref=f11e173]: Loading…
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f11e174] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f11e175]

--- a/.playwright-mcp/page-2026-08-03T05-29-19-775Z.yml
+++ b/.playwright-mcp/page-2026-08-03T05-29-19-775Z.yml
@@ -1,0 +1,179 @@
+- generic [active] [ref=f13e1]:
+  - banner [ref=f13e2]:
+    - generic [ref=f13e3]:
+      - heading "Symfony Exception" [level=1] [ref=f13e4]
+      - link "Symfony Docs" [ref=f13e8] [cursor=pointer]:
+        - /url: https://symfony.com/doc/7.4.13/index.html
+  - generic [ref=f13e12]:
+    - generic [ref=f13e14]:
+      - heading [level=2] [ref=f13e15]:
+        - link "SyntaxError" [ref=f13e16] [cursor=pointer]:
+          - /url: "#trace-box-1"
+      - heading "HTTP 500 Internal Server Error" [level=2] [ref=f13e17]
+    - 'heading "A template that extends another one cannot include content outside Twig blocks. Did you forget to put the content inside a {% block %} tag in Coupon44/Resource/template/default/shopping_coupon.twig at line 76?" [level=1] [ref=f13e20]'
+  - generic [ref=f13e25]:
+    - tablist [ref=f13e26]:
+      - tab "Exception" [selected] [ref=f13e27] [cursor=pointer]
+      - tab "Logs 2" [ref=f13e28] [cursor=pointer]:
+        - text: Logs
+        - generic [ref=f13e29]: "2"
+      - tab "Stack Trace" [ref=f13e30] [cursor=pointer]
+    - tabpanel [ref=f13e31]:
+      - generic [ref=f13e34]:
+        - generic [ref=f13e35]:
+          - heading "Twig\\Error\\ SyntaxError" [level=3] [ref=f13e40] [cursor=pointer]:
+            - generic [ref=f13e41]: Twig\Error\
+            - text: SyntaxError
+          - group [ref=f13e42]:
+            - generic "Show exception properties" [ref=f13e43] [cursor=pointer]
+        - generic [ref=f13e44]:
+          - generic [ref=f13e45]:
+            - generic [ref=f13e50] [cursor=pointer]:
+              - text: in
+              - link [ref=f13e51]:
+                - /url: file:///var/www/html/app/template/default/Coupon44/Resource/template/default/shopping_coupon.twig#L76
+                - text: app/template/default/Coupon44/Resource/template/default/
+                - strong [ref=f13e52]: shopping_coupon.twig
+              - text: (line 76)
+            - list [ref=f13e54]:
+              - listitem [ref=f13e55]:
+                - code [ref=f13e56]: </form>
+              - listitem [ref=f13e57]:
+                - code [ref=f13e58]: </div>
+              - listitem [ref=f13e59]:
+                - code [ref=f13e60]: </div>
+              - listitem [ref=f13e61]:
+                - code [ref=f13e62]: </div>
+              - listitem [ref=f13e63]:
+                - code [ref=f13e64]: "{% endblock %}"
+              - listitem [ref=f13e65]:
+                - code
+              - listitem [ref=f13e66]:
+                - code [ref=f13e67]: <p>COUPON-PAGE-EDIT-MARKER-197</p>
+              - listitem [ref=f13e68]:
+                - code
+          - generic [ref=f13e74] [cursor=pointer]:
+            - text: in
+            - link [ref=f13e75]:
+              - /url: file:///var/www/html/vendor/twig/twig/src/Parser.php#L593
+              - text: vendor/twig/twig/src/
+              - strong [ref=f13e76]: Parser.php
+            - text: "-> filterBodyNodes (line 593)"
+          - generic [ref=f13e82] [cursor=pointer]:
+            - text: in
+            - link [ref=f13e83]:
+              - /url: file:///var/www/html/vendor/twig/twig/src/Parser.php#L112
+              - text: vendor/twig/twig/src/
+              - strong [ref=f13e84]: Parser.php
+            - text: "-> filterBodyNodes (line 112)"
+          - generic [ref=f13e90] [cursor=pointer]:
+            - text: in
+            - link [ref=f13e91]:
+              - /url: file:///var/www/html/vendor/twig/twig/src/Environment.php#L558
+              - text: vendor/twig/twig/src/
+              - strong [ref=f13e92]: Environment.php
+            - text: "-> parse (line 558)"
+          - generic [ref=f13e98] [cursor=pointer]:
+            - text: in
+            - link [ref=f13e99]:
+              - /url: file:///var/www/html/vendor/twig/twig/src/Environment.php#L589
+              - text: vendor/twig/twig/src/
+              - strong [ref=f13e100]: Environment.php
+            - text: "-> parse (line 589)"
+          - generic [ref=f13e106] [cursor=pointer]:
+            - text: in
+            - link [ref=f13e107]:
+              - /url: file:///var/www/html/vendor/twig/twig/src/Environment.php#L408
+              - text: vendor/twig/twig/src/
+              - strong [ref=f13e108]: Environment.php
+            - text: "-> compileSource (line 408)"
+          - generic [ref=f13e118] [cursor=pointer]:
+            - text: in
+            - link [ref=f13e119]:
+              - /url: file:///var/www/html/vendor/twig/twig/src/Environment.php#L370
+              - text: vendor/twig/twig/src/
+              - strong [ref=f13e120]: Environment.php
+            - text: "-> loadTemplate (line 370)"
+          - generic [ref=f13e126] [cursor=pointer]:
+            - text: in
+            - link [ref=f13e127]:
+              - /url: file:///var/www/html/vendor/twig/twig/src/Environment.php#L333
+              - text: vendor/twig/twig/src/
+              - strong [ref=f13e128]: Environment.php
+            - text: "-> load (line 333)"
+          - generic [ref=f13e134] [cursor=pointer]:
+            - text: in
+            - link [ref=f13e135]:
+              - /url: file:///var/www/html/vendor/symfony/twig-bridge/EventListener/TemplateAttributeListener.php#L66
+              - text: vendor/symfony/twig-bridge/EventListener/
+              - strong [ref=f13e136]: TemplateAttributeListener.php
+            - text: "-> render (line 66)"
+          - generic [ref=f13e142] [cursor=pointer]:
+            - text: in
+            - link [ref=f13e143]:
+              - /url: file:///var/www/html/vendor/symfony/event-dispatcher/Debug/WrappedListener.php#L115
+              - text: vendor/symfony/event-dispatcher/Debug/
+              - strong [ref=f13e144]: WrappedListener.php
+            - text: "-> onKernelView (line 115)"
+          - generic [ref=f13e150] [cursor=pointer]:
+            - text: in
+            - link [ref=f13e151]:
+              - /url: file:///var/www/html/vendor/symfony/event-dispatcher/EventDispatcher.php#L206
+              - text: vendor/symfony/event-dispatcher/
+              - strong [ref=f13e152]: EventDispatcher.php
+            - text: "-> __invoke (line 206)"
+          - generic [ref=f13e158] [cursor=pointer]:
+            - text: in
+            - link [ref=f13e159]:
+              - /url: file:///var/www/html/vendor/symfony/event-dispatcher/EventDispatcher.php#L56
+              - text: vendor/symfony/event-dispatcher/
+              - strong [ref=f13e160]: EventDispatcher.php
+            - text: "-> callListeners (line 56)"
+          - generic [ref=f13e166] [cursor=pointer]:
+            - text: in
+            - link [ref=f13e167]:
+              - /url: file:///var/www/html/vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php#L129
+              - text: vendor/symfony/event-dispatcher/Debug/
+              - strong [ref=f13e168]: TraceableEventDispatcher.php
+            - text: "-> dispatch (line 129)"
+          - generic [ref=f13e174] [cursor=pointer]:
+            - text: in
+            - link [ref=f13e175]:
+              - /url: file:///var/www/html/vendor/symfony/http-kernel/HttpKernel.php#L188
+              - text: vendor/symfony/http-kernel/
+              - strong [ref=f13e176]: HttpKernel.php
+            - text: "-> dispatch (line 188)"
+          - generic [ref=f13e182] [cursor=pointer]:
+            - text: in
+            - link [ref=f13e183]:
+              - /url: file:///var/www/html/vendor/symfony/http-kernel/HttpKernel.php#L76
+              - text: vendor/symfony/http-kernel/
+              - strong [ref=f13e184]: HttpKernel.php
+            - text: "-> handleRaw (line 76)"
+          - generic [ref=f13e190] [cursor=pointer]:
+            - text: in
+            - link [ref=f13e191]:
+              - /url: file:///var/www/html/vendor/symfony/http-kernel/Kernel.php#L193
+              - text: vendor/symfony/http-kernel/
+              - strong [ref=f13e192]: Kernel.php
+            - text: "-> handle (line 193)"
+          - generic [ref=f13e194] [cursor=pointer]:
+            - generic [ref=f13e198]: Kernel
+            - text: "->handle()"
+            - generic [ref=f13e199]:
+              - text: in
+              - link "index.php/" [ref=f13e200]:
+                - /url: file:///var/www/html/index.php#L100
+                - text: index.php/
+                - strong
+              - text: (line 100)
+    - text: ✔ ▾ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ▾
+  - region "Symfony Web Debug Toolbar" [ref=f13e201]:
+    - generic [ref=f13e204]:
+      - link "Symfony Loading…" [ref=f13e206] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/59171a?panel=request
+        - generic [ref=f13e207]:
+          - img "Symfony" [ref=f13e208]
+          - generic [ref=f13e210]: Loading…
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f13e211] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f13e212]

--- a/.playwright-mcp/page-2026-08-03T05-29-44-051Z.yml
+++ b/.playwright-mcp/page-2026-08-03T05-29-44-051Z.yml
@@ -1,0 +1,175 @@
+- generic [active] [ref=f14e1]:
+  - generic [ref=f14e2]: デバッグモードが有効になっています。
+  - generic [ref=f14e6]:
+    - banner [ref=f14e7]:
+      - generic [ref=f14e8]:
+        - generic [ref=f14e9]:
+          - generic [ref=f14e11]:
+            - generic:
+              - combobox [ref=f14e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f14e16]:
+                - searchbox "キーワードを入力" [ref=f14e17]
+                - button [ref=f14e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f14e20]:
+          - generic [ref=f14e22]:
+            - link " 新規会員登録" [ref=f14e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f14e25]: 
+              - generic [ref=f14e26]: 新規会員登録
+            - link " お気に入り" [ref=f14e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f14e29]: 
+              - generic [ref=f14e30]: お気に入り
+            - link " ログイン" [ref=f14e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f14e33]: 
+              - generic [ref=f14e34]: ログイン
+          - generic [ref=f14e37] [cursor=pointer]:
+            - generic [ref=f14e38]:
+              - text: 
+              - generic [ref=f14e39]: "2"
+            - generic [ref=f14e40]: ￥6,160
+      - heading [level=1] [ref=f14e46]:
+        - link "EC-CUBE SHOP" [ref=f14e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f14e50]:
+        - listitem [ref=f14e51]:
+          - link "新入荷" [ref=f14e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f14e53]:
+          - link "ジェラート" [ref=f14e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f14e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f14e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f14e57]:
+          - link "アイスサンド" [ref=f14e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f14e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f14e61]:
+      - paragraph [ref=f14e62]: COUPON-PAGE-EDIT-MARKER-197
+      - heading "クーポンコードの入力" [level=1] [ref=f14e65]
+      - generic [ref=f14e68]:
+        - generic [ref=f14e69]: 利用するクーポンコードを入力してください。
+        - generic [ref=f14e71]:
+          - generic [ref=f14e72]:
+            - generic [ref=f14e73]:
+              - term [ref=f14e74]
+              - definition [ref=f14e75]:
+                - generic [ref=f14e76]:
+                  - generic [ref=f14e77]:
+                    - radio "クーポンを利用しない" [ref=f14e78]
+                    - generic [ref=f14e79]: クーポンを利用しない
+                  - generic [ref=f14e80]:
+                    - radio "クーポンを利用する" [checked] [ref=f14e81]
+                    - generic [ref=f14e82]: クーポンを利用する
+            - generic [ref=f14e83]:
+              - term [ref=f14e84]:
+                - generic [ref=f14e85]: クーポンコード
+              - definition [ref=f14e86]:
+                - textbox "クーポンコード" [ref=f14e87]
+          - generic [ref=f14e90]:
+            - button "登録する" [ref=f14e91] [cursor=pointer]
+            - link "戻る" [ref=f14e92] [cursor=pointer]:
+              - /url: http://localhost:8080/shopping
+    - contentinfo [ref=f14e93]:
+      - generic [ref=f14e95]:
+        - list [ref=f14e96]:
+          - listitem [ref=f14e97]:
+            - link "当サイトについて" [ref=f14e98] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f14e99]:
+            - link "プライバシーポリシー" [ref=f14e100] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f14e101]:
+            - link "特定商取引法に基づく表記" [ref=f14e102] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f14e103]:
+            - link "お問い合わせ" [ref=f14e104] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f14e105]:
+          - link "EC-CUBE SHOP" [ref=f14e107] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f14e108]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f14e109]:
+    - generic [ref=f14e112]:
+      - link "200 @ plugin_coupon_shopping" [ref=f14e114] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b9cd0a?panel=request
+        - generic [ref=f14e115]:
+          - generic [ref=f14e116]: "200"
+          - generic [ref=f14e117]: "@"
+          - generic [ref=f14e118]: plugin_coupon_shopping
+      - link "145 ms" [ref=f14e120] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b9cd0a?panel=time
+        - generic [ref=f14e121]:
+          - generic [ref=f14e122]: "145"
+          - generic [ref=f14e123]: ms
+      - link "12.0 MiB" [ref=f14e125] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b9cd0a?panel=time
+        - generic [ref=f14e126]:
+          - generic [ref=f14e127]: "12.0"
+          - generic [ref=f14e128]: MiB
+      - link "Cache 2" [ref=f14e130] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b9cd0a?panel=form
+        - generic [ref=f14e131]:
+          - img "Cache" [ref=f14e132]
+          - generic [ref=f14e138]: "2"
+      - link "Logger 481" [ref=f14e140] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b9cd0a?panel=logger
+        - generic [ref=f14e141]:
+          - img "Logger" [ref=f14e142]
+          - generic [ref=f14e146]: "481"
+      - link "Cache 20 in 0.34 ms" [ref=f14e148] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b9cd0a?panel=cache
+        - generic [ref=f14e149]:
+          - img "Cache" [ref=f14e150]
+          - generic [ref=f14e155]: "20"
+          - generic [ref=f14e156]: in 0.34 ms
+      - link "27" [ref=f14e158] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b9cd0a?panel=translation
+      - link "Security n/a" [ref=f14e167] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b9cd0a?panel=security
+        - generic [ref=f14e168]:
+          - img "Security" [ref=f14e169]
+          - generic [ref=f14e173]: n/a
+      - link "Twig 39 ms" [ref=f14e175] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b9cd0a?panel=twig
+        - generic [ref=f14e176]:
+          - img "Twig" [ref=f14e177]
+          - generic [ref=f14e181]: "39"
+          - generic [ref=f14e182]: ms
+      - link "21 in 3.33 ms" [ref=f14e184] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b9cd0a?panel=db
+        - generic [ref=f14e185]:
+          - generic [ref=f14e191]: "21"
+          - generic [ref=f14e192]: in 3.33 ms
+      - link "22" [ref=f14e194] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b9cd0a?panel=doctrine_migrations
+      - link "Symfony 7.4.13" [ref=f14e201] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b9cd0a?panel=config
+        - generic [ref=f14e202]:
+          - img "Symfony" [ref=f14e204]
+          - generic [ref=f14e206]: 7.4.13
+      - generic [ref=f14e208]:
+        - img "eccube_logo_basic" [ref=f14e209]
+        - generic [ref=f14e214]: 4.3.1-p1
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f14e215] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f14e216]

--- a/.playwright-mcp/page-2026-08-03T05-30-36-393Z.yml
+++ b/.playwright-mcp/page-2026-08-03T05-30-36-393Z.yml
@@ -1,0 +1,175 @@
+- generic [active] [ref=f16e1]:
+  - generic [ref=f16e2]: デバッグモードが有効になっています。
+  - generic [ref=f16e6]:
+    - banner [ref=f16e7]:
+      - generic [ref=f16e8]:
+        - generic [ref=f16e9]:
+          - generic [ref=f16e11]:
+            - generic:
+              - combobox [ref=f16e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f16e16]:
+                - searchbox "キーワードを入力" [ref=f16e17]
+                - button [ref=f16e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f16e20]:
+          - generic [ref=f16e22]:
+            - link " 新規会員登録" [ref=f16e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f16e25]: 
+              - generic [ref=f16e26]: 新規会員登録
+            - link " お気に入り" [ref=f16e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f16e29]: 
+              - generic [ref=f16e30]: お気に入り
+            - link " ログイン" [ref=f16e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f16e33]: 
+              - generic [ref=f16e34]: ログイン
+          - generic [ref=f16e37] [cursor=pointer]:
+            - generic [ref=f16e38]:
+              - text: 
+              - generic [ref=f16e39]: "2"
+            - generic [ref=f16e40]: ￥6,160
+      - heading [level=1] [ref=f16e46]:
+        - link "EC-CUBE SHOP" [ref=f16e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f16e50]:
+        - listitem [ref=f16e51]:
+          - link "新入荷" [ref=f16e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f16e53]:
+          - link "ジェラート" [ref=f16e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f16e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f16e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f16e57]:
+          - link "アイスサンド" [ref=f16e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f16e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f16e61]:
+      - paragraph [ref=f16e62]: COUPON-PAGE-EDIT-MARKER-197
+      - heading "クーポンコードの入力" [level=1] [ref=f16e65]
+      - generic [ref=f16e68]:
+        - generic [ref=f16e69]: 利用するクーポンコードを入力してください。
+        - generic [ref=f16e71]:
+          - generic [ref=f16e72]:
+            - generic [ref=f16e73]:
+              - term [ref=f16e74]
+              - definition [ref=f16e75]:
+                - generic [ref=f16e76]:
+                  - generic [ref=f16e77]:
+                    - radio "クーポンを利用しない" [ref=f16e78]
+                    - generic [ref=f16e79]: クーポンを利用しない
+                  - generic [ref=f16e80]:
+                    - radio "クーポンを利用する" [checked] [ref=f16e81]
+                    - generic [ref=f16e82]: クーポンを利用する
+            - generic [ref=f16e83]:
+              - term [ref=f16e84]:
+                - generic [ref=f16e85]: クーポンコード
+              - definition [ref=f16e86]:
+                - textbox "クーポンコード" [ref=f16e87]
+          - generic [ref=f16e90]:
+            - button "登録する" [ref=f16e91] [cursor=pointer]
+            - link "戻る" [ref=f16e92] [cursor=pointer]:
+              - /url: http://localhost:8080/shopping
+    - contentinfo [ref=f16e93]:
+      - generic [ref=f16e95]:
+        - list [ref=f16e96]:
+          - listitem [ref=f16e97]:
+            - link "当サイトについて" [ref=f16e98] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f16e99]:
+            - link "プライバシーポリシー" [ref=f16e100] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f16e101]:
+            - link "特定商取引法に基づく表記" [ref=f16e102] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f16e103]:
+            - link "お問い合わせ" [ref=f16e104] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f16e105]:
+          - link "EC-CUBE SHOP" [ref=f16e107] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f16e108]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f16e109]:
+    - generic [ref=f16e112]:
+      - link "200 @ plugin_coupon_shopping" [ref=f16e114] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b455d1?panel=request
+        - generic [ref=f16e115]:
+          - generic [ref=f16e116]: "200"
+          - generic [ref=f16e117]: "@"
+          - generic [ref=f16e118]: plugin_coupon_shopping
+      - link "116 ms" [ref=f16e120] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b455d1?panel=time
+        - generic [ref=f16e121]:
+          - generic [ref=f16e122]: "116"
+          - generic [ref=f16e123]: ms
+      - link "12.0 MiB" [ref=f16e125] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b455d1?panel=time
+        - generic [ref=f16e126]:
+          - generic [ref=f16e127]: "12.0"
+          - generic [ref=f16e128]: MiB
+      - link "Cache 2" [ref=f16e130] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b455d1?panel=form
+        - generic [ref=f16e131]:
+          - img "Cache" [ref=f16e132]
+          - generic [ref=f16e138]: "2"
+      - link "Logger 479" [ref=f16e140] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b455d1?panel=logger
+        - generic [ref=f16e141]:
+          - img "Logger" [ref=f16e142]
+          - generic [ref=f16e146]: "479"
+      - link "Cache 20 in 0.24 ms" [ref=f16e148] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b455d1?panel=cache
+        - generic [ref=f16e149]:
+          - img "Cache" [ref=f16e150]
+          - generic [ref=f16e155]: "20"
+          - generic [ref=f16e156]: in 0.24 ms
+      - link "27" [ref=f16e158] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b455d1?panel=translation
+      - link "Security n/a" [ref=f16e167] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b455d1?panel=security
+        - generic [ref=f16e168]:
+          - img "Security" [ref=f16e169]
+          - generic [ref=f16e173]: n/a
+      - link "Twig 37 ms" [ref=f16e175] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b455d1?panel=twig
+        - generic [ref=f16e176]:
+          - img "Twig" [ref=f16e177]
+          - generic [ref=f16e181]: "37"
+          - generic [ref=f16e182]: ms
+      - link "21 in 3.60 ms" [ref=f16e184] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b455d1?panel=db
+        - generic [ref=f16e185]:
+          - generic [ref=f16e191]: "21"
+          - generic [ref=f16e192]: in 3.60 ms
+      - link "22" [ref=f16e194] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b455d1?panel=doctrine_migrations
+      - link "Symfony 7.4.13" [ref=f16e201] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b455d1?panel=config
+        - generic [ref=f16e202]:
+          - img "Symfony" [ref=f16e204]
+          - generic [ref=f16e206]: 7.4.13
+      - generic [ref=f16e208]:
+        - img "eccube_logo_basic" [ref=f16e209]
+        - generic [ref=f16e214]: 4.3.1-p1
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f16e215] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f16e216]

--- a/.playwright-mcp/page-2026-08-03T05-31-25-683Z.yml
+++ b/.playwright-mcp/page-2026-08-03T05-31-25-683Z.yml
@@ -1,0 +1,174 @@
+- generic [active] [ref=f18e1]:
+  - generic [ref=f18e2]: デバッグモードが有効になっています。
+  - generic [ref=f18e6]:
+    - banner [ref=f18e7]:
+      - generic [ref=f18e8]:
+        - generic [ref=f18e9]:
+          - generic [ref=f18e11]:
+            - generic:
+              - combobox [ref=f18e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f18e16]:
+                - searchbox "キーワードを入力" [ref=f18e17]
+                - button [ref=f18e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f18e20]:
+          - generic [ref=f18e22]:
+            - link " 新規会員登録" [ref=f18e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f18e25]: 
+              - generic [ref=f18e26]: 新規会員登録
+            - link " お気に入り" [ref=f18e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f18e29]: 
+              - generic [ref=f18e30]: お気に入り
+            - link " ログイン" [ref=f18e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f18e33]: 
+              - generic [ref=f18e34]: ログイン
+          - generic [ref=f18e37] [cursor=pointer]:
+            - generic [ref=f18e38]:
+              - text: 
+              - generic [ref=f18e39]: "2"
+            - generic [ref=f18e40]: ￥6,160
+      - heading [level=1] [ref=f18e46]:
+        - link "EC-CUBE SHOP" [ref=f18e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f18e50]:
+        - listitem [ref=f18e51]:
+          - link "新入荷" [ref=f18e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f18e53]:
+          - link "ジェラート" [ref=f18e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f18e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f18e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f18e57]:
+          - link "アイスサンド" [ref=f18e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f18e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f18e61]:
+      - heading "お届け先の複数指定" [level=1] [ref=f18e64]
+      - generic [ref=f18e66]:
+        - paragraph [ref=f18e68]: 各商品のお届け先を選択してください。
+        - link "新規お届け先を追加する" [ref=f18e70] [cursor=pointer]:
+          - /url: http://localhost:8080/shopping/shipping_multiple_edit
+        - generic [ref=f18e71]:
+          - generic [ref=f18e75]:
+            - generic [ref=f18e76]: チェリーアイスサンド
+            - generic [ref=f18e77]: 小計：￥6,160
+            - generic [ref=f18e78]: 数量：2
+          - generic [ref=f18e80]:
+            - generic [ref=f18e82]:
+              - generic [ref=f18e83]: お届け先
+              - combobox [ref=f18e84]:
+                - option "検証 大阪府 大阪市北区梅田 1-1-1" [selected]
+            - generic [ref=f18e86]:
+              - generic [ref=f18e87]: 数量
+              - spinbutton [ref=f18e88]: "2"
+          - button "お届け先追加" [ref=f18e90] [cursor=pointer]
+        - generic [ref=f18e91]:
+          - button "選択したお届け先に送る" [ref=f18e92] [cursor=pointer]
+          - link "戻る" [ref=f18e93] [cursor=pointer]:
+            - /url: http://localhost:8080/shopping
+    - contentinfo [ref=f18e94]:
+      - generic [ref=f18e96]:
+        - list [ref=f18e97]:
+          - listitem [ref=f18e98]:
+            - link "当サイトについて" [ref=f18e99] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f18e100]:
+            - link "プライバシーポリシー" [ref=f18e101] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f18e102]:
+            - link "特定商取引法に基づく表記" [ref=f18e103] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f18e104]:
+            - link "お問い合わせ" [ref=f18e105] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f18e106]:
+          - link "EC-CUBE SHOP" [ref=f18e108] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f18e109]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f18e110]:
+    - generic [ref=f18e113]:
+      - link "200 Redirect @ shopping_shipping_multiple" [ref=f18e115] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/5652c2?panel=request
+        - generic [ref=f18e116]:
+          - generic [ref=f18e117]: "200"
+          - img "Redirect" [ref=f18e119]
+          - generic [ref=f18e122]: "@"
+          - generic [ref=f18e123]: shopping_shipping_multiple
+      - link "136 ms" [ref=f18e125] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/5652c2?panel=time
+        - generic [ref=f18e126]:
+          - generic [ref=f18e127]: "136"
+          - generic [ref=f18e128]: ms
+      - link "12.0 MiB" [ref=f18e130] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/5652c2?panel=time
+        - generic [ref=f18e131]:
+          - generic [ref=f18e132]: "12.0"
+          - generic [ref=f18e133]: MiB
+      - link "Cache 2" [ref=f18e135] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/5652c2?panel=form
+        - generic [ref=f18e136]:
+          - img "Cache" [ref=f18e137]
+          - generic [ref=f18e143]: "2"
+      - link "Logger 488" [ref=f18e145] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/5652c2?panel=logger
+        - generic [ref=f18e146]:
+          - img "Logger" [ref=f18e147]
+          - generic [ref=f18e151]: "488"
+      - link "Cache 22 in 0.38 ms" [ref=f18e153] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/5652c2?panel=cache
+        - generic [ref=f18e154]:
+          - img "Cache" [ref=f18e155]
+          - generic [ref=f18e160]: "22"
+          - generic [ref=f18e161]: in 0.38 ms
+      - link "1" [ref=f18e163] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/5652c2?panel=translation
+      - link "Security n/a" [ref=f18e172] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/5652c2?panel=security
+        - generic [ref=f18e173]:
+          - img "Security" [ref=f18e174]
+          - generic [ref=f18e178]: n/a
+      - link "Twig 37 ms" [ref=f18e180] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/5652c2?panel=twig
+        - generic [ref=f18e181]:
+          - img "Twig" [ref=f18e182]
+          - generic [ref=f18e186]: "37"
+          - generic [ref=f18e187]: ms
+      - link "24 in 4.38 ms" [ref=f18e189] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/5652c2?panel=db
+        - generic [ref=f18e190]:
+          - generic [ref=f18e196]: "24"
+          - generic [ref=f18e197]: in 4.38 ms
+      - link "22" [ref=f18e199] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/5652c2?panel=doctrine_migrations
+      - link "Symfony 7.4.13" [ref=f18e206] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/5652c2?panel=config
+        - generic [ref=f18e207]:
+          - img "Symfony" [ref=f18e209]
+          - generic [ref=f18e211]: 7.4.13
+      - generic [ref=f18e213]:
+        - img "eccube_logo_basic" [ref=f18e214]
+        - generic [ref=f18e219]: 4.3.1-p1
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f18e220] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f18e221]

--- a/.playwright-mcp/page-2026-08-03T05-32-24-404Z.yml
+++ b/.playwright-mcp/page-2026-08-03T05-32-24-404Z.yml
@@ -1,0 +1,208 @@
+- generic [active] [ref=f20e1]:
+  - generic [ref=f20e2]: デバッグモードが有効になっています。
+  - generic [ref=f20e6]:
+    - banner [ref=f20e7]:
+      - generic [ref=f20e8]:
+        - generic [ref=f20e9]:
+          - generic [ref=f20e11]:
+            - generic:
+              - combobox [ref=f20e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f20e16]:
+                - searchbox "キーワードを入力" [ref=f20e17]
+                - button [ref=f20e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f20e20]:
+          - generic [ref=f20e22]:
+            - link " 新規会員登録" [ref=f20e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f20e25]: 
+              - generic [ref=f20e26]: 新規会員登録
+            - link " お気に入り" [ref=f20e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f20e29]: 
+              - generic [ref=f20e30]: お気に入り
+            - link " ログイン" [ref=f20e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f20e33]: 
+              - generic [ref=f20e34]: ログイン
+          - generic [ref=f20e37] [cursor=pointer]:
+            - generic [ref=f20e38]:
+              - text: 
+              - generic [ref=f20e39]: "2"
+            - generic [ref=f20e40]: ￥6,160
+      - heading [level=1] [ref=f20e46]:
+        - link "EC-CUBE SHOP" [ref=f20e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f20e50]:
+        - listitem [ref=f20e51]:
+          - link "新入荷" [ref=f20e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f20e53]:
+          - link "ジェラート" [ref=f20e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f20e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f20e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f20e57]:
+          - link "アイスサンド" [ref=f20e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f20e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f20e61]:
+      - heading "ご注文手続き" [level=1] [ref=f20e64]
+      - list [ref=f20e67]:
+        - listitem [ref=f20e68]:
+          - generic [ref=f20e69]: "1"
+          - generic [ref=f20e70]: カートの商品
+        - listitem [ref=f20e71]:
+          - generic [ref=f20e72]: "2"
+          - generic [ref=f20e73]: お客様情報
+        - listitem [ref=f20e74]:
+          - generic [ref=f20e75]: "3"
+          - generic [ref=f20e76]: ご注文手続き
+        - listitem [ref=f20e77]:
+          - generic [ref=f20e78]: "4"
+          - generic [ref=f20e79]: ご注文内容確認
+        - listitem [ref=f20e80]:
+          - generic [ref=f20e81]: "5"
+          - generic [ref=f20e82]: 完了
+      - generic [ref=f20e84]:
+        - generic [ref=f20e85]:
+          - generic [ref=f20e86]:
+            - heading "お客様情報" [level=2] [ref=f20e88]
+            - button "変更" [ref=f20e90] [cursor=pointer]
+            - generic [ref=f20e91]:
+              - paragraph [ref=f20e92]: 検証 太郎 様
+              - paragraph [ref=f20e93]: ケンショウ タロウ
+              - paragraph
+              - paragraph [ref=f20e94]:
+                - text: 〒
+                - generic [ref=f20e95]: "5300001"
+              - paragraph [ref=f20e96]: 大阪府大阪市北区梅田1-1-1
+              - paragraph [ref=f20e97]: "0669999999"
+              - paragraph [ref=f20e98]: test197@example.com
+          - generic [ref=f20e99]:
+            - heading "配送情報" [level=2] [ref=f20e101]
+            - generic [ref=f20e102]:
+              - text: お届け先
+              - button "変更" [ref=f20e104] [cursor=pointer]
+            - generic [ref=f20e105]:
+              - list [ref=f20e106]:
+                - listitem [ref=f20e107]:
+                  - generic [ref=f20e108]:
+                    - img "チェリーアイスサンド" [ref=f20e110]
+                    - generic [ref=f20e111]:
+                      - paragraph [ref=f20e112]: チェリーアイスサンド
+                      - paragraph [ref=f20e113]: ￥3,080 × 2小計：￥6,160
+              - paragraph
+            - generic [ref=f20e114]:
+              - paragraph [ref=f20e115]: 検証 太郎 (ケンショウ タロウ) 様
+              - paragraph [ref=f20e116]: 〒5300001 大阪府大阪市北区梅田1-1-1
+              - paragraph [ref=f20e117]: "0669999999"
+            - generic [ref=f20e119]:
+              - generic [ref=f20e120]:
+                - generic [ref=f20e121]: 配送方法
+                - combobox [ref=f20e122]:
+                  - option "サンプル業者" [selected]
+              - generic [ref=f20e123]:
+                - generic [ref=f20e124]: お届け日
+                - combobox [ref=f20e125]:
+                  - option "指定なし" [selected]
+              - generic [ref=f20e126]:
+                - generic [ref=f20e127]: お届け時間
+                - combobox [ref=f20e128]:
+                  - option "指定なし" [selected]
+                  - option "午前"
+                  - option "午後"
+            - button "お届け先を追加する" [ref=f20e130] [cursor=pointer]
+          - generic [ref=f20e131]:
+            - heading "お支払方法" [level=2] [ref=f20e133]
+            - generic [ref=f20e134]:
+              - generic [ref=f20e135]:
+                - radio "郵便振替" [checked] [ref=f20e136]
+                - generic [ref=f20e137]: 郵便振替
+              - generic [ref=f20e138]:
+                - radio "現金書留" [ref=f20e139]
+                - generic [ref=f20e140]: 現金書留
+              - generic [ref=f20e141]:
+                - radio "銀行振込" [ref=f20e142]
+                - generic [ref=f20e143]: 銀行振込
+              - generic [ref=f20e144]:
+                - radio "代金引換" [ref=f20e145]
+                - generic [ref=f20e146]: 代金引換
+          - generic [ref=f20e147]:
+            - heading "クーポン" [level=2] [ref=f20e149]
+            - generic [ref=f20e150]:
+              - strong [ref=f20e151]: クーポンコード TESTCOUPON197 を利用しています。
+              - paragraph [ref=f20e152]:
+                - link "クーポンを変更する" [ref=f20e153] [cursor=pointer]:
+                  - /url: http://localhost:8080/plugin/coupon/shopping/shopping_coupon
+          - generic [ref=f20e154]:
+            - heading "お問い合わせ" [level=2] [ref=f20e156]
+            - textbox "お問い合わせ事項がございましたら、こちらにご入力ください。(3000文字まで)" [ref=f20e158]
+        - generic [ref=f20e160]:
+          - generic [ref=f20e161]:
+            - term [ref=f20e162]: 小計
+            - definition [ref=f20e163]: ￥6,160
+          - generic [ref=f20e164]:
+            - term [ref=f20e165]: 手数料
+            - definition [ref=f20e166]: ￥0
+          - generic [ref=f20e167]:
+            - term [ref=f20e168]: 送料
+            - definition [ref=f20e169]: ￥1,000
+          - generic [ref=f20e170]: 合計￥7,160税込
+          - generic [ref=f20e171]:
+            - term [ref=f20e172]: 検証用クーポン197
+            - definition [ref=f20e173]: "-￥500"
+          - generic [ref=f20e174]: お支払い合計￥6,660税込
+          - generic [ref=f20e175]:
+            - term [ref=f20e176]: "[ 税率 10 %対象"
+            - definition [ref=f20e177]: ￥6,660 (内消費税 ￥605) ]
+          - generic [ref=f20e178]:
+            - button "確認する" [ref=f20e179] [cursor=pointer]
+            - link "カートに戻る" [ref=f20e180] [cursor=pointer]:
+              - /url: http://localhost:8080/cart
+    - contentinfo [ref=f20e181]:
+      - generic [ref=f20e183]:
+        - list [ref=f20e184]:
+          - listitem [ref=f20e185]:
+            - link "当サイトについて" [ref=f20e186] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f20e187]:
+            - link "プライバシーポリシー" [ref=f20e188] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f20e189]:
+            - link "特定商取引法に基づく表記" [ref=f20e190] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f20e191]:
+            - link "お問い合わせ" [ref=f20e192] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f20e193]:
+          - link "EC-CUBE SHOP" [ref=f20e195] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f20e196]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f20e197]:
+    - generic [ref=f20e200]:
+      - link "Symfony Loading…" [ref=f20e202] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/b0bee8?panel=request
+        - generic [ref=f20e203]:
+          - img "Symfony" [ref=f20e204]
+          - generic [ref=f20e206]: Loading…
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f20e207] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f20e208]

--- a/.playwright-mcp/page-2026-08-03T05-32-31-517Z.yml
+++ b/.playwright-mcp/page-2026-08-03T05-32-31-517Z.yml
@@ -1,0 +1,174 @@
+- generic [active] [ref=f21e1]:
+  - generic [ref=f21e2]: デバッグモードが有効になっています。
+  - generic [ref=f21e6]:
+    - banner [ref=f21e7]:
+      - generic [ref=f21e8]:
+        - generic [ref=f21e9]:
+          - generic [ref=f21e11]:
+            - generic:
+              - combobox [ref=f21e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f21e16]:
+                - searchbox "キーワードを入力" [ref=f21e17]
+                - button [ref=f21e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f21e20]:
+          - generic [ref=f21e22]:
+            - link " 新規会員登録" [ref=f21e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f21e25]: 
+              - generic [ref=f21e26]: 新規会員登録
+            - link " お気に入り" [ref=f21e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f21e29]: 
+              - generic [ref=f21e30]: お気に入り
+            - link " ログイン" [ref=f21e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f21e33]: 
+              - generic [ref=f21e34]: ログイン
+          - generic [ref=f21e37] [cursor=pointer]:
+            - generic [ref=f21e38]:
+              - text: 
+              - generic [ref=f21e39]: "2"
+            - generic [ref=f21e40]: ￥6,160
+      - heading [level=1] [ref=f21e46]:
+        - link "EC-CUBE SHOP" [ref=f21e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f21e50]:
+        - listitem [ref=f21e51]:
+          - link "新入荷" [ref=f21e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f21e53]:
+          - link "ジェラート" [ref=f21e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f21e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f21e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f21e57]:
+          - link "アイスサンド" [ref=f21e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f21e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f21e61]:
+      - heading "お届け先の複数指定" [level=1] [ref=f21e64]
+      - generic [ref=f21e66]:
+        - paragraph [ref=f21e68]: 各商品のお届け先を選択してください。
+        - link "新規お届け先を追加する" [ref=f21e70] [cursor=pointer]:
+          - /url: http://localhost:8080/shopping/shipping_multiple_edit
+        - generic [ref=f21e71]:
+          - generic [ref=f21e75]:
+            - generic [ref=f21e76]: チェリーアイスサンド
+            - generic [ref=f21e77]: 小計：￥6,160
+            - generic [ref=f21e78]: 数量：2
+          - generic [ref=f21e80]:
+            - generic [ref=f21e82]:
+              - generic [ref=f21e83]: お届け先
+              - combobox [ref=f21e84]:
+                - option "検証 大阪府 大阪市北区梅田 1-1-1" [selected]
+            - generic [ref=f21e86]:
+              - generic [ref=f21e87]: 数量
+              - spinbutton [ref=f21e88]: "2"
+          - button "お届け先追加" [ref=f21e90] [cursor=pointer]
+        - generic [ref=f21e91]:
+          - button "選択したお届け先に送る" [ref=f21e92] [cursor=pointer]
+          - link "戻る" [ref=f21e93] [cursor=pointer]:
+            - /url: http://localhost:8080/shopping
+    - contentinfo [ref=f21e94]:
+      - generic [ref=f21e96]:
+        - list [ref=f21e97]:
+          - listitem [ref=f21e98]:
+            - link "当サイトについて" [ref=f21e99] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f21e100]:
+            - link "プライバシーポリシー" [ref=f21e101] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f21e102]:
+            - link "特定商取引法に基づく表記" [ref=f21e103] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f21e104]:
+            - link "お問い合わせ" [ref=f21e105] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f21e106]:
+          - link "EC-CUBE SHOP" [ref=f21e108] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f21e109]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f21e110]:
+    - generic [ref=f21e113]:
+      - link "200 Redirect @ shopping_shipping_multiple" [ref=f21e115] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6fff15?panel=request
+        - generic [ref=f21e116]:
+          - generic [ref=f21e117]: "200"
+          - img "Redirect" [ref=f21e119]
+          - generic [ref=f21e122]: "@"
+          - generic [ref=f21e123]: shopping_shipping_multiple
+      - link "138 ms" [ref=f21e125] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6fff15?panel=time
+        - generic [ref=f21e126]:
+          - generic [ref=f21e127]: "138"
+          - generic [ref=f21e128]: ms
+      - link "12.0 MiB" [ref=f21e130] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6fff15?panel=time
+        - generic [ref=f21e131]:
+          - generic [ref=f21e132]: "12.0"
+          - generic [ref=f21e133]: MiB
+      - link "Cache 2" [ref=f21e135] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6fff15?panel=form
+        - generic [ref=f21e136]:
+          - img "Cache" [ref=f21e137]
+          - generic [ref=f21e143]: "2"
+      - link "Logger 494" [ref=f21e145] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6fff15?panel=logger
+        - generic [ref=f21e146]:
+          - img "Logger" [ref=f21e147]
+          - generic [ref=f21e151]: "494"
+      - link "Cache 22 in 0.32 ms" [ref=f21e153] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6fff15?panel=cache
+        - generic [ref=f21e154]:
+          - img "Cache" [ref=f21e155]
+          - generic [ref=f21e160]: "22"
+          - generic [ref=f21e161]: in 0.32 ms
+      - link "1" [ref=f21e163] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6fff15?panel=translation
+      - link "Security n/a" [ref=f21e172] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6fff15?panel=security
+        - generic [ref=f21e173]:
+          - img "Security" [ref=f21e174]
+          - generic [ref=f21e178]: n/a
+      - link "Twig 40 ms" [ref=f21e180] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6fff15?panel=twig
+        - generic [ref=f21e181]:
+          - img "Twig" [ref=f21e182]
+          - generic [ref=f21e186]: "40"
+          - generic [ref=f21e187]: ms
+      - link "24 in 4.50 ms" [ref=f21e189] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6fff15?panel=db
+        - generic [ref=f21e190]:
+          - generic [ref=f21e196]: "24"
+          - generic [ref=f21e197]: in 4.50 ms
+      - link "22" [ref=f21e199] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6fff15?panel=doctrine_migrations
+      - link "Symfony 7.4.13" [ref=f21e206] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/6fff15?panel=config
+        - generic [ref=f21e207]:
+          - img "Symfony" [ref=f21e209]
+          - generic [ref=f21e211]: 7.4.13
+      - generic [ref=f21e213]:
+        - img "eccube_logo_basic" [ref=f21e214]
+        - generic [ref=f21e219]: 4.3.1-p1
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f21e220] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f21e221]

--- a/.playwright-mcp/page-2026-08-03T05-33-00-632Z.yml
+++ b/.playwright-mcp/page-2026-08-03T05-33-00-632Z.yml
@@ -1,0 +1,118 @@
+- generic [active] [ref=f23e1]:
+  - generic [ref=f23e2]: デバッグモードが有効になっています。
+  - generic [ref=f23e6]:
+    - banner [ref=f23e7]:
+      - generic [ref=f23e8]:
+        - generic [ref=f23e9]:
+          - generic [ref=f23e11]:
+            - generic:
+              - combobox [ref=f23e14] [cursor=pointer]:
+                - option "全ての商品" [selected]
+                - option "新入荷"
+                - option "ジェラート"
+                - option "彩のデザート"
+                - option "CUBE"
+                - option "アイスサンド"
+                - option "フルーツ"
+              - generic [ref=f23e16]:
+                - searchbox "キーワードを入力" [ref=f23e17]
+                - button [ref=f23e18] [cursor=pointer]
+          - generic: 
+        - generic [ref=f23e20]:
+          - generic [ref=f23e22]:
+            - link " 新規会員登録" [ref=f23e24] [cursor=pointer]:
+              - /url: http://localhost:8080/entry
+              - generic [ref=f23e25]: 
+              - generic [ref=f23e26]: 新規会員登録
+            - link " お気に入り" [ref=f23e28] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/favorite
+              - generic [ref=f23e29]: 
+              - generic [ref=f23e30]: お気に入り
+            - link " ログイン" [ref=f23e32] [cursor=pointer]:
+              - /url: http://localhost:8080/mypage/login
+              - generic [ref=f23e33]: 
+              - generic [ref=f23e34]: ログイン
+          - generic [ref=f23e37] [cursor=pointer]:
+            - generic [ref=f23e38]:
+              - text: 
+              - generic [ref=f23e39]: "2"
+            - generic [ref=f23e40]: ￥6,160
+      - heading [level=1] [ref=f23e46]:
+        - link "EC-CUBE SHOP" [ref=f23e47] [cursor=pointer]:
+          - /url: http://localhost:8080/
+      - list [ref=f23e50]:
+        - listitem [ref=f23e51]:
+          - link "新入荷" [ref=f23e52] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=2
+        - listitem [ref=f23e53]:
+          - link "ジェラート" [ref=f23e54] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=1
+          - list:
+            - listitem:
+              - link "彩のデザート" [ref=f23e55] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=3
+              - list:
+                - text: 
+                - listitem:
+                  - link "CUBE" [ref=f23e56] [cursor=pointer]:
+                    - /url: http://localhost:8080/products/list?category_id=4
+        - listitem [ref=f23e57]:
+          - link "アイスサンド" [ref=f23e58] [cursor=pointer]:
+            - /url: http://localhost:8080/products/list?category_id=5
+          - list:
+            - listitem:
+              - link "フルーツ" [ref=f23e59] [cursor=pointer]:
+                - /url: http://localhost:8080/products/list?category_id=6
+    - main [ref=f23e61]:
+      - heading "お届け先の複数指定" [level=1] [ref=f23e64]
+      - generic [ref=f23e66]:
+        - paragraph [ref=f23e68]: 各商品のお届け先を選択してください。
+        - link "新規お届け先を追加する" [ref=f23e70] [cursor=pointer]:
+          - /url: http://localhost:8080/shopping/shipping_multiple_edit
+        - generic [ref=f23e71]:
+          - generic [ref=f23e75]:
+            - generic [ref=f23e76]: チェリーアイスサンド
+            - generic [ref=f23e77]: 小計：￥6,160
+            - generic [ref=f23e78]: 数量：2
+          - generic [ref=f23e80]:
+            - generic [ref=f23e82]:
+              - generic [ref=f23e83]: お届け先
+              - combobox [ref=f23e84]:
+                - option "検証 大阪府 大阪市北区梅田 1-1-1" [selected]
+            - generic [ref=f23e86]:
+              - generic [ref=f23e87]: 数量
+              - spinbutton [ref=f23e88]: "2"
+          - button "お届け先追加" [ref=f23e90] [cursor=pointer]
+        - generic [ref=f23e91]:
+          - button "選択したお届け先に送る" [ref=f23e92] [cursor=pointer]
+          - link "戻る" [ref=f23e93] [cursor=pointer]:
+            - /url: http://localhost:8080/shopping
+    - contentinfo [ref=f23e94]:
+      - generic [ref=f23e96]:
+        - list [ref=f23e97]:
+          - listitem [ref=f23e98]:
+            - link "当サイトについて" [ref=f23e99] [cursor=pointer]:
+              - /url: http://localhost:8080/help/about
+          - listitem [ref=f23e100]:
+            - link "プライバシーポリシー" [ref=f23e101] [cursor=pointer]:
+              - /url: http://localhost:8080/help/privacy
+          - listitem [ref=f23e102]:
+            - link "特定商取引法に基づく表記" [ref=f23e103] [cursor=pointer]:
+              - /url: http://localhost:8080/help/tradelaw
+          - listitem [ref=f23e104]:
+            - link "お問い合わせ" [ref=f23e105] [cursor=pointer]:
+              - /url: http://localhost:8080/contact
+        - generic [ref=f23e106]:
+          - link "EC-CUBE SHOP" [ref=f23e108] [cursor=pointer]:
+            - /url: http://localhost:8080/
+          - generic [ref=f23e109]: copyright (c) EC-CUBE SHOP all rights reserved.
+  - text:       
+  - region "Symfony Web Debug Toolbar" [ref=f23e110]:
+    - generic [ref=f23e113]:
+      - link "Symfony Loading…" [ref=f23e115] [cursor=pointer]:
+        - /url: http://localhost:8080/_profiler/fc2108?panel=request
+        - generic [ref=f23e116]:
+          - img "Symfony" [ref=f23e117]
+          - generic [ref=f23e119]: Loading…
+      - button "Toggle Symfony Toolbar" [expanded] [ref=f23e120] [cursor=pointer]:
+        - generic "Close Toolbar" [ref=f23e121]

--- a/Resource/template/admin/regist.twig
+++ b/Resource/template/admin/regist.twig
@@ -408,7 +408,7 @@
                                                         </div>
                                                     </div>
                                                     <div class="col-1 icon_edit">
-                                                        <a class="btn btn-ec-actionIcon mr-3 delete-item" data-bs-toggle="modal" data-bs-toggle="tooltip" data-bs-target="#confirmModal" data-bs-placement="top" title="{{ 'admin.common.delete'|trans }}">
+                                                        <a class="btn btn-ec-actionIcon me-3 delete-item" data-bs-toggle="modal" data-bs-toggle="tooltip" data-bs-target="#confirmModal" data-bs-placement="top" title="{{ 'admin.common.delete'|trans }}">
                                                             <i class="fa fa-close fa-lg text-secondary"></i>
                                                         </a>
                                                     </div>
@@ -447,7 +447,7 @@
                         <div class="collapse show ec-cardCollapse" style="display: block;" id="categoryArea">
                             <div class="card-body">
                                 <div class="text-center">
-                                    <a id="showSearchCategoryModal" class="btn btn-ec-regular mr-2 add" data-bs-toggle="modal" data-bs-target="#searchCategoryModal">カテゴリの追加</a>
+                                    <a id="showSearchCategoryModal" class="btn btn-ec-regular me-2 add" data-bs-toggle="modal" data-bs-target="#searchCategoryModal">カテゴリの追加</a>
                                 </div>
                                 <div class="tableish"
                                      id="coupon_detail_list2"
@@ -470,7 +470,7 @@
                                                     </div>
 
                                                     <div class="col-1 icon_edit">
-                                                        <a class="btn btn-ec-actionIcon mr-3 delete-item" data-bs-toggle="modal" data-bs-toggle="tooltip" data-bs-target="#confirmModal" data-bs-placement="top" title="{{ 'admin.common.delete'|trans }}">
+                                                        <a class="btn btn-ec-actionIcon me-3 delete-item" data-bs-toggle="modal" data-bs-toggle="tooltip" data-bs-target="#confirmModal" data-bs-placement="top" title="{{ 'admin.common.delete'|trans }}">
                                                             <i class="fa fa-close fa-lg text-secondary"></i>
                                                         </a>
                                                     </div>

--- a/Resource/template/admin/regist_category_list_prototype.twig
+++ b/Resource/template/admin/regist_category_list_prototype.twig
@@ -13,7 +13,7 @@
         </div>
 
         <div class="col-1 icon_edit">
-            <a class="btn btn-ec-actionIcon mr-3 delete-item" data-bs-toggle="modal" data-bs-toggle="tooltip" data-bs-target="#confirmModal" data-bs-placement="top" title="{{ 'admin.common.delete'|trans }}">
+            <a class="btn btn-ec-actionIcon me-3 delete-item" data-bs-toggle="modal" data-bs-toggle="tooltip" data-bs-target="#confirmModal" data-bs-placement="top" title="{{ 'admin.common.delete'|trans }}">
                 <i class="fa fa-close fa-lg text-secondary"></i>
             </a>
         </div>

--- a/Resource/template/admin/regist_product_list_prototype.twig
+++ b/Resource/template/admin/regist_product_list_prototype.twig
@@ -14,7 +14,7 @@
             </div>
         </div>
         <div class="col-1 icon_edit">
-            <a class="btn btn-ec-actionIcon mr-3 delete-item" data-bs-toggle="modal" data-bs-toggle="tooltip" data-bs-target="#confirmModal" data-bs-placement="top" title="{{ 'admin.common.delete'|trans }}">
+            <a class="btn btn-ec-actionIcon me-3 delete-item" data-bs-toggle="modal" data-bs-toggle="tooltip" data-bs-target="#confirmModal" data-bs-placement="top" title="{{ 'admin.common.delete'|trans }}">
                 <i class="fa fa-close fa-lg text-secondary"></i>
             </a>
         </div>


### PR DESCRIPTION
## 概要

管理画面のクーポン登録画面に Bootstrap 4 の右マージンユーティリティ（`mr-*`）が残っており、**何のスタイルも当たっていません**。Bootstrap 5 では `me-*` にリネームされているため、ボタン／アイコンの余白が詰まって表示されます。

[#197](https://github.com/EC-CUBE/coupon-plugin/pull/197) のレビューで nanasess から指摘された既存不具合で、4.4 対応ブランチ側は #197 に同梱して修正済みです。default ブランチ (`4.2`) にも同じ 5 箇所が存在するため、こちらにも反映します。

## 変更内容

| ファイル | 行 | 変更 |
|---|---|---|
| `Resource/template/admin/regist.twig` | 411 / 473 | `mr-3` → `me-3` |
| `Resource/template/admin/regist.twig` | 450 | `mr-2` → `me-2` |
| `Resource/template/admin/regist_product_list_prototype.twig` | 17 | `mr-3` → `me-3` |
| `Resource/template/admin/regist_category_list_prototype.twig` | 16 | `mr-3` → `me-3` |

## 根拠

- 管理画面の `html/template/admin/assets/css/bootstrap.css` に `.mr-2` のルールは **存在しません**（`.me-2` は存在します）
- 同じ `regist.twig` の 391 行だけが `me-2` になっており不統一でした
- 他の Bootstrap 4 残骸（`ml-*` / `pr-*` / `float-left` / `badge-*` / `sr-only` など）は grep で 0 件のため、本 PR の対象は上記 5 箇所のみです

テンプレートのクラス名のみの変更で、ロジック・テストへの影響はありません。


## CI について（追加コミット 75fd402）

本 PR を出した時点で、`4.2` ブランチの CI が**全ジョブ failure** になっていました。原因はテンプレート変更ではなく、GitHub 側で `actions/cache` v1 が廃止され、ワークフローが自動的に失敗するようになったためです。

```
##[error]This request has been automatically failed because it uses a
deprecated version of `actions/cache: v1`.
```

本 PR の内容を CI で検証できるようにするため、最小限だけ追随しています。

- `actions/cache@v1` → `@v4`
- `::set-output` → `$GITHUB_OUTPUT`（同じく非推奨）

`actions/checkout@v2` などの他の古い action は本 PR では触っていません。CI 更新を別 PR に分けたい場合はお知らせください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * ショップのトップ、商品一覧・詳細、カート、ログイン、顧客情報入力、注文手続き、クーポン、複数配送先指定などの画面状態を追加しました。
  * 管理画面のホーム、ページ管理、クーポン登録画面のアクセシビリティ情報を追加しました。
  * 正常画面に加え、エラー画面の表示状態も記録しました。

* **スタイル**
  * 管理画面のボタンやリンクの余白表示を現行のデザイン仕様に合わせました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
