### PR TITLE
fix: CI 復旧 (actions/cache@v4) と 4.3 でのテスト失敗・Bootstrap 5 クラス名の修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,8 @@ jobs:
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - uses: actions/cache@v1
+          echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/Resource/template/admin/regist.twig
+++ b/Resource/template/admin/regist.twig
@@ -408,7 +408,7 @@
                                                         </div>
                                                     </div>
                                                     <div class="col-1 icon_edit">
-                                                        <a class="btn btn-ec-actionIcon mr-3 delete-item" data-bs-toggle="modal" data-bs-toggle="tooltip" data-bs-target="#confirmModal" data-bs-placement="top" title="{{ 'admin.common.delete'|trans }}">
+                                                        <a class="btn btn-ec-actionIcon me-3 delete-item" data-bs-toggle="modal" data-bs-toggle="tooltip" data-bs-target="#confirmModal" data-bs-placement="top" title="{{ 'admin.common.delete'|trans }}">
                                                             <i class="fa fa-close fa-lg text-secondary"></i>
                                                         </a>
                                                     </div>
@@ -447,7 +447,7 @@
                         <div class="collapse show ec-cardCollapse" style="display: block;" id="categoryArea">
                             <div class="card-body">
                                 <div class="text-center">
-                                    <a id="showSearchCategoryModal" class="btn btn-ec-regular mr-2 add" data-bs-toggle="modal" data-bs-target="#searchCategoryModal">カテゴリの追加</a>
+                                    <a id="showSearchCategoryModal" class="btn btn-ec-regular me-2 add" data-bs-toggle="modal" data-bs-target="#searchCategoryModal">カテゴリの追加</a>
                                 </div>
                                 <div class="tableish"
                                      id="coupon_detail_list2"
@@ -470,7 +470,7 @@
                                                     </div>
 
                                                     <div class="col-1 icon_edit">
-                                                        <a class="btn btn-ec-actionIcon mr-3 delete-item" data-bs-toggle="modal" data-bs-toggle="tooltip" data-bs-target="#confirmModal" data-bs-placement="top" title="{{ 'admin.common.delete'|trans }}">
+                                                        <a class="btn btn-ec-actionIcon me-3 delete-item" data-bs-toggle="modal" data-bs-toggle="tooltip" data-bs-target="#confirmModal" data-bs-placement="top" title="{{ 'admin.common.delete'|trans }}">
                                                             <i class="fa fa-close fa-lg text-secondary"></i>
                                                         </a>
                                                     </div>

--- a/Resource/template/admin/regist_category_list_prototype.twig
+++ b/Resource/template/admin/regist_category_list_prototype.twig
@@ -13,7 +13,7 @@
         </div>
 
         <div class="col-1 icon_edit">
-            <a class="btn btn-ec-actionIcon mr-3 delete-item" data-bs-toggle="modal" data-bs-toggle="tooltip" data-bs-target="#confirmModal" data-bs-placement="top" title="{{ 'admin.common.delete'|trans }}">
+            <a class="btn btn-ec-actionIcon me-3 delete-item" data-bs-toggle="modal" data-bs-toggle="tooltip" data-bs-target="#confirmModal" data-bs-placement="top" title="{{ 'admin.common.delete'|trans }}">
                 <i class="fa fa-close fa-lg text-secondary"></i>
             </a>
         </div>

--- a/Resource/template/admin/regist_product_list_prototype.twig
+++ b/Resource/template/admin/regist_product_list_prototype.twig
@@ -14,7 +14,7 @@
             </div>
         </div>
         <div class="col-1 icon_edit">
-            <a class="btn btn-ec-actionIcon mr-3 delete-item" data-bs-toggle="modal" data-bs-toggle="tooltip" data-bs-target="#confirmModal" data-bs-placement="top" title="{{ 'admin.common.delete'|trans }}">
+            <a class="btn btn-ec-actionIcon me-3 delete-item" data-bs-toggle="modal" data-bs-toggle="tooltip" data-bs-target="#confirmModal" data-bs-placement="top" title="{{ 'admin.common.delete'|trans }}">
                 <i class="fa fa-close fa-lg text-secondary"></i>
             </a>
         </div>

--- a/Tests/Service/CouponServiceTest.php
+++ b/Tests/Service/CouponServiceTest.php
@@ -387,7 +387,8 @@ class CouponServiceTest extends EccubeTestCase
 
         $this->actual = $discount;
         $this->expected = (int) round(round($total) * $discountRate / 100);
-        $this->verify();
+        // decimal カラムは Doctrine が文字列で返すため数値等価で比較する
+        self::assertEquals($this->expected, $this->actual);
     }
 
     /**
@@ -449,7 +450,8 @@ class CouponServiceTest extends EccubeTestCase
 
         $this->actual = $discount;
         $this->expected = (int) round(round($total) * $discountRate / 100);
-        $this->verify();
+        // decimal カラムは Doctrine が文字列で返すため数値等価で比較する
+        self::assertEquals($this->expected, $this->actual);
     }
 
     /**

--- a/Tests/Web/CouponControllerTest.php
+++ b/Tests/Web/CouponControllerTest.php
@@ -164,7 +164,8 @@ class CouponControllerTest extends AbstractShoppingControllerTestCase
 
         $this->expected = round(0 - $Coupon->getDiscountPrice(), 2);
         $this->actual = $Order->getItems()->getDiscounts()->first()->getPrice();
-        $this->verify();
+        // decimal カラムは Doctrine が文字列で返すため数値等価で比較する
+        self::assertEquals($this->expected, $this->actual);
     }
 
     /**
@@ -259,7 +260,8 @@ class CouponControllerTest extends AbstractShoppingControllerTestCase
 
         $this->actual = $Coupon->getDiscountPrice();
         $this->expected = 0 - $Order->getItems()->getDiscounts()->first()->getPrice();
-        $this->verify();
+        // decimal カラムは Doctrine が文字列で返すため数値等価で比較する
+        self::assertEquals($this->expected, $this->actual);
     }
 
     /**
@@ -300,7 +302,8 @@ class CouponControllerTest extends AbstractShoppingControllerTestCase
 
         $this->actual = $CouponOrder->getDiscount();
         $this->expected = 0 - $Order->getItems()->getDiscounts()->first()->getPrice();
-        $this->verify();
+        // decimal カラムは Doctrine が文字列で返すため数値等価で比較する
+        self::assertEquals($this->expected, $this->actual);
     }
 
     /**
@@ -358,7 +361,8 @@ class CouponControllerTest extends AbstractShoppingControllerTestCase
 
         $this->actual = $Coupon->getDiscountPrice();
         $this->expected = 0 - $Order->getItems()->getDiscounts()->first()->getPrice();
-        $this->verify();
+        // decimal カラムは Doctrine が文字列で返すため数値等価で比較する
+        self::assertEquals($this->expected, $this->actual);
     }
 
     /**


### PR DESCRIPTION
## 概要

default ブランチ (`4.2`) の CI が壊れていたため、**CI の復旧**・**EC-CUBE 4.3 との組み合わせで失敗していたテストの追随**・**Bootstrap 5 のクラス名修正**を行います。

Bootstrap のクラス名修正は [#197](https://github.com/EC-CUBE/coupon-plugin/pull/197) のレビューで nanasess から指摘された既存不具合（4.4 対応ブランチ側は #197 に同梱済み）を default ブランチにも反映するものです。

（当初 #200 として出しましたが、CI が全ジョブ落ちる状態だったため作業ファイルの混入もあわせて整理し、出し直しました）

## コミット

### 1. `fix(ci)`: 廃止された `actions/cache@v1` と `::set-output` を更新

GitHub 側で `actions/cache` v1 が廃止され、ワークフローが**自動的に失敗**するようになっていました。そのため本ブランチの CI は全ジョブ failure で、内容の検証ができない状態でした。

```
##[error]This request has been automatically failed because it uses a
deprecated version of `actions/cache: v1`.
```

- `actions/cache@v1` → `@v4`
- `::set-output` → `$GITHUB_OUTPUT`（同じく非推奨）

`actions/checkout@v2` などの他の古い action は本 PR では触っていません。

### 2. `fix(test)`: decimal カラムの比較を `assertEquals` にする

上記を直すと CI が動き出し、**EC-CUBE 4.3 との組み合わせで 6 テストが失敗**していることが分かりました（`4.2` との組み合わせは pass）。decimal カラムを Doctrine が文字列で返すようになったため、`verify()`（`assertSame`）の厳密比較が通らないものです。

```
CouponServiceTest::testRecalcOrderDiscountRate
  Failed asserting that '623.00' is identical to 623.
CouponControllerTest::testShoppingCoupon
  Failed asserting that '-100.00' is identical to -100.0.
```

金額の等価性を検証したいだけなので数値等価（`assertEquals`）に変更しました。#197 でも 4.4 向けに同じ方針で対応しています。

| ファイル | 箇所 |
|---|---|
| `Tests/Service/CouponServiceTest.php` | 2 箇所（`testRecalcOrderDiscountRate` / `testRecalcOrderWithTaxRateIsEmpty`） |
| `Tests/Web/CouponControllerTest.php` | 4 箇所（`testShoppingCoupon` / `testShoppingCouponDiscountTypePrice` / `testShoppingCouponDiscountTypeRate` / `testCompleteWithNonmember`） |

### 3. `fix`: Bootstrap 5 に存在しない `mr-2` / `mr-3` を `me-2` / `me-3` に修正

Bootstrap 5.3 では右マージンのユーティリティが `me-*` にリネームされているため、`mr-*` は**何のスタイルも当たっていません**（ボタン／アイコンの余白が詰まって表示されます）。

| ファイル | 行 | 変更 |
|---|---|---|
| `Resource/template/admin/regist.twig` | 411 / 473 | `mr-3` → `me-3` |
| `Resource/template/admin/regist.twig` | 450 | `mr-2` → `me-2` |
| `Resource/template/admin/regist_product_list_prototype.twig` | 17 | `mr-3` → `me-3` |
| `Resource/template/admin/regist_category_list_prototype.twig` | 16 | `mr-3` → `me-3` |

根拠:

- admin の `html/template/admin/assets/css/bootstrap.css` に `.mr-2` のルールは **存在しません**（`.me-2` は存在します）
- 同じ `regist.twig` の 391 行だけが `me-2` になっており不統一でした
- 他の Bootstrap 4 残骸（`ml-*` / `pr-*` / `float-left` / `badge-*` / `sr-only` など）は grep で 0 件のため対象外です

## テスト

CI（EC-CUBE 4.2 / 4.3 × PHP 7.4〜8.3 × MySQL 5.7 / MySQL 8 / PostgreSQL の全 18 ジョブ）で確認します。コミット 1 の適用前は全ジョブが起動すらしない状態でした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
