### PR TITLE
test: 受注キャンセル遷移を検証する E2E (Playwright) を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,10 @@ jobs:
         env:
           PLUGIN_CODE: ${{ matrix.plugin_code }}
         run: |
-          tar cvzf ${GITHUB_WORKSPACE}/${PLUGIN_CODE}.tar.gz ./*
+          # E2E (Playwright) の資産はプラグインの配布物ではないため除外する
+          tar cvzf ${GITHUB_WORKSPACE}/${PLUGIN_CODE}.tar.gz \
+            --exclude='./e2e' --exclude='./playwright.config.ts' \
+            --exclude='./package.json' --exclude='./package-lock.json' ./*
       - name: Checkout EC-CUBE
         uses: actions/checkout@v4
         with:
@@ -196,7 +199,9 @@ jobs:
 
       - name: Archive Plugin
         run: |
-          tar cvzf ${GITHUB_WORKSPACE}/${PLUGIN_CODE}.tar.gz ./*
+          tar cvzf ${GITHUB_WORKSPACE}/${PLUGIN_CODE}.tar.gz \
+            --exclude='./e2e' --exclude='./playwright.config.ts' \
+            --exclude='./package.json' --exclude='./package-lock.json' ./*
       - name: Checkout EC-CUBE
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,9 @@ jobs:
       - name: Setup EC-CUBE
         working-directory: 'ec-cube'
         run: |
-          bin/console doctrine:database:create
+          # SQLite はファイルベースで CREATE DATABASE が無く, DBAL 4 では
+          # SQLitePlatform::getCreateDatabaseSQL が未サポートで例外になるため
+          # doctrine:database:create は実行しない (schema:create が DB ファイルを生成する)。
           bin/console doctrine:schema:create
           # プラグイン有効化時に DeviceType 等のマスタデータを参照するため fixtures を投入する
           bin/console eccube:fixtures:load

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,10 @@ on:
       - '**'
       - '!*.md'
   pull_request:
+    # '*' はスラッシュにマッチしないため、'feature/xxx' を base にしたスタック PR で
+    # ワークフローが起動しなくなる。base ブランチは '**' で受ける
     branches:
-      - '*'
+      - '**'
     paths:
       - '**'
       - '!*.md'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,9 @@ jobs:
           rm -rf $GITHUB_WORKSPACE/docker-compose*.yml $GITHUB_WORKSPACE/dockerbuild
           rm -f $GITHUB_WORKSPACE/CLAUDE.md $GITHUB_WORKSPACE/phpstan.neon.dist
           rm -f $GITHUB_WORKSPACE/Resource/rector.php "$GITHUB_WORKSPACE/Resource/.php-cs-fixer.dist.php"
+          # E2E (Playwright) も開発用のため含めない
+          rm -rf $GITHUB_WORKSPACE/e2e $GITHUB_WORKSPACE/node_modules
+          rm -f $GITHUB_WORKSPACE/playwright.config.ts $GITHUB_WORKSPACE/package.json $GITHUB_WORKSPACE/package-lock.json
           find $GITHUB_WORKSPACE -name "dummy" -delete
           find $GITHUB_WORKSPACE -name ".git*" -and ! -name ".gitkeep" -print0 | xargs -0 rm -rf
           chmod -R o+w $GITHUB_WORKSPACE

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,85 @@
+name: E2E for Coupon44
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - '*'
+    paths:
+      - '**'
+      - '!*.md'
+  pull_request:
+    branches:
+      - '*'
+    paths:
+      - '**'
+      - '!*.md'
+
+# GITHUB_TOKEN は最小権限（読み取りのみ）にする
+permissions:
+  contents: read
+
+jobs:
+  playwright:
+    name: Playwright (${{ matrix.tag }} / ${{ matrix.db }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # PHPUnit の CI (ci.yml) が全 PHP バージョンを網羅するため、E2E は下限と上限のみ実行する。
+        # DB は 3 種類とも回す（キャンセル遷移は悲観ロックを伴い DB による差異が出るため）。
+        tag: [ '8.2-apache-4.4', '8.5-apache-4.4' ]
+        db: [ 'sqlite3', 'mysql', 'pgsql' ]
+    env:
+      TAG: ${{ matrix.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup COMPOSE_FILE
+        env:
+          DB: ${{ matrix.db }}
+        run: |
+          if [ "${DB}" = 'sqlite3' ]; then
+            echo "COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml" >> "${GITHUB_ENV}"
+          else
+            echo "COMPOSE_FILE=docker-compose.yml:docker-compose.${DB}.yml:docker-compose.dev.yml" >> "${GITHUB_ENV}"
+          fi
+
+      - name: Setup EC-CUBE
+        # docker-compose.dev.yml の entrypoint が本体のインストールとプラグインの
+        # インストール・有効化まで行う
+        run: docker compose up -d --wait
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        env:
+          CI: 1
+          FORCE_COLOR: 1
+        run: npx playwright test
+
+      - name: Show EC-CUBE log
+        if: failure()
+        run: docker compose logs ec-cube
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report-${{ matrix.tag }}-${{ matrix.db }}
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,8 +9,10 @@ on:
       - '**'
       - '!*.md'
   pull_request:
+    # '*' はスラッシュにマッチしないため、'feature/xxx' を base にしたスタック PR で
+    # ワークフローが起動しなくなる。base ブランチは '**' で受ける
     branches:
-      - '*'
+      - '**'
     paths:
       - '**'
       - '!*.md'

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ composer.lock
 
 # Playwright MCP の一時生成物
 /.playwright-mcp/
+
+# E2E (Playwright) の依存・生成物
+/node_modules/
+/playwright-report/
+/test-results/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,36 @@ docker compose exec ec-cube bash -lc \
 
 **注意（コンパイル済みキャッシュ）**: 有効化したプラグインのルーティングは、コンテナのコンパイル時に `dtb_plugin` を読む `EccubeExtension` で確定する。有効化直後の test キャッシュには反映されていないことがあるため、**PHPUnit 実行前に `APP_ENV=test` でキャッシュをクリアする**。これを怠るとコントローラのルートが `RouteNotFoundException` になる。
 
+### E2E（Playwright）
+
+`Tests/` の PHPUnit とは別に、`e2e/` に Playwright の E2E テストがある。`docker compose` で起動した
+EC-CUBE（プラグイン有効化済み・`APP_ENV=dev`）に実ブラウザでアクセスして検証する。CI は
+`.github/workflows/playwright.yml`（PHPUnit の `ci.yml` とは別ワークフロー）。
+
+```bash
+# EC-CUBE を起動しておく（上記の開発環境と同じ）
+export COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml
+docker compose up -d --wait
+
+npm ci
+npx playwright install chromium
+npx playwright test              # ヘッドレス実行
+npx playwright test --headed     # ブラウザを表示して実行
+```
+
+接続先は `ECCUBE_BASE_URL`（既定 `http://localhost:8080`）で切り替えられる。
+
+**PHPUnit で書けないケースの受け皿**: 受注ステータスを「注文取消し」へ遷移させると本体の
+`StockReduceProcessor` が `EntityManager::lock(PESSIMISTIC_WRITE)` を行うが、`APP_ENV=test` では
+dama/doctrine-test-bundle のトランザクションが DBAL `Connection` 上で開いていないため
+`TransactionRequiredException` になる（EC-CUBE/ec-cube#7016。`Tests/Web/Admin/OrderControllerTest::testOrderEditWithCouponCancel`
+はこのためスキップしている）。E2E は prod と同じく `TransactionListener` が有効な実リクエストのため
+この制約を受けない。**受注ステータス遷移を伴う検証は E2E に書くこと。**
+
+E2E は 1 つの EC-CUBE インスタンスを共有し、クーポンの発行枚数や受注ステータスというグローバルな
+状態を書き換えるため、`playwright.config.ts` で `workers: 1` / `fullyParallel: false` にしている。
+クーポンコードはテストごとに `E2E${Date.now()}` で一意にし、テスト間の干渉を避ける。
+
 ### 静的解析・整形（任意）
 
 EC-CUBE 本体（コンテナ内）の vendor を使って実行する。
@@ -101,6 +131,11 @@ Plugin\:
 ### プラグイン有効化後は `cache:clear` を 2 回実行する（TemplateEvent 対策）
 
 本プラグインは `Event.php` が `TemplateEvent` で core テンプレート（購入画面・マイページ・受注編集）にスニペットを注入する。これらプラグイン由来のフックは、**`eccube:plugin:enable` 直後の 1 回の `cache:clear` では確定しない**ことがある。検証の結果、enable とは別パスで **`cache:clear` をもう一度実行**すると確定するため、`docker-compose.dev.yml` の entrypoint は有効化後に `bin/console cache:clear` を **2 回** 実行する。
+
+### E2E の資産はプラグインの配布物に含めない
+
+`e2e/` `playwright.config.ts` `package.json` `package-lock.json` は開発用で、プラグインの配布物では
+ないため、`docker-compose.dev.yml` と `.github/workflows/ci.yml` の tar から `--exclude` する。
 
 ### プラグインの導入方法（tar + plugin:install）
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,8 +86,10 @@ docker compose exec ec-cube bash -lc \
   "cd app/Plugin/Coupon44 && /var/www/html/vendor/bin/php-cs-fixer fix --config=Resource/.php-cs-fixer.dist.php --dry-run --diff"
 
 # rector（再移行・検証用）
+# composer-based セットが vendor/composer/installed.json を読むため、本体のルートで実行する
+# （プラグインディレクトリに cd すると "The installed package json not found" で失敗する）
 docker compose exec ec-cube bash -lc \
-  "cd app/Plugin/Coupon44 && /var/www/html/vendor/bin/rector process --config=Resource/rector.php --dry-run"
+  "cd /var/www/html && ./vendor/bin/rector process --config=app/Plugin/Coupon44/Resource/rector.php --dry-run"
 
 # phpstan
 docker compose exec ec-cube bash -lc \

--- a/Controller/CouponShoppingController.php
+++ b/Controller/CouponShoppingController.php
@@ -132,7 +132,8 @@ class CouponShoppingController extends AbstractController
             // ----------------------------------
             // 値引き項目追加 / 合計金額上書き
             // ----------------------------------
-            if (!$error && $Coupon) {
+            // $Coupon が null の場合は上で $error = true にしているため、!$error なら非 null
+            if (!$error) {
                 $couponProducts = $service->existsCouponProduct($Coupon, $Order);
                 $discount = $service->recalcOrder($Coupon, $couponProducts);
 

--- a/Controller/CouponShoppingController.php
+++ b/Controller/CouponShoppingController.php
@@ -18,7 +18,6 @@ use Eccube\Entity\Customer;
 use Eccube\Entity\Order;
 use Eccube\Service\CartService;
 use Eccube\Service\OrderHelper;
-use Plugin\Coupon44\Entity\Coupon;
 use Plugin\Coupon44\Form\Type\CouponUseType;
 use Plugin\Coupon44\Repository\CouponOrderRepository;
 use Plugin\Coupon44\Repository\CouponRepository;
@@ -103,8 +102,7 @@ class CouponShoppingController extends AbstractController
             // クーポンを利用する
             $discount = 0;
             $error = false;
-            // クーポン情報を取得
-            /* @var $Coupon Coupon */
+            // クーポン情報を取得 (findActiveCoupon が ?Coupon を返すため @var は不要)
             $Coupon = $this->couponRepository->findActiveCoupon($formCouponCd);
             if (!$Coupon) {
                 $form->get('coupon_cd')->addError(new FormError(trans('plugin_coupon.front.shopping.notexists')));

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # クーポンプラグイン
 
 [![CI for Coupon44](https://github.com/EC-CUBE/coupon-plugin/actions/workflows/ci.yml/badge.svg)](https://github.com/EC-CUBE/coupon-plugin/actions/workflows/ci.yml)
+[![E2E for Coupon44](https://github.com/EC-CUBE/coupon-plugin/actions/workflows/playwright.yml/badge.svg)](https://github.com/EC-CUBE/coupon-plugin/actions/workflows/playwright.yml)
 
 ## 概要
 

--- a/Resource/rector.php
+++ b/Resource/rector.php
@@ -41,11 +41,14 @@ return RectorConfig::configure()
     ->withSets([
         LevelSetList::UP_TO_PHP_82,
         // Symfony 7.4 対応 (@Route → #[Route], @Template, buildForm(): void 等)
-        SymfonySetList::SYMFONY_74,
+        // 各ルールが composer.json / installed.json を見てインストール済みバージョンに合うものだけ
+        // 実行する。rector 2.6.2 でバージョン別のセット定数 (SYMFONY_74 等) は撤去された
+        // (本体の対応: EC-CUBE/ec-cube#7099)
+        SymfonySetList::COMPOSER_BASED,
         SymfonySetList::SYMFONY_CODE_QUALITY,
         // Doctrine ORM 3.0 / DBAL 3.0 対応 (@ORM → #[ORM], 型付きプロパティ)
         DoctrineSetList::DOCTRINE_CODE_QUALITY,
-        DoctrineSetList::DOCTRINE_DBAL_30,
+        DoctrineSetList::COMPOSER_BASED,
         DoctrineSetList::ANNOTATIONS_TO_ATTRIBUTES,
     ])
     // Symfony/Doctrine 等のアノテーション → アトリビュート変換を有効化

--- a/Service/PurchaseFlow/Processor/CouponProcessor.php
+++ b/Service/PurchaseFlow/Processor/CouponProcessor.php
@@ -27,7 +27,6 @@ use Eccube\Service\PurchaseFlow\ItemHolderValidator;
 use Eccube\Service\PurchaseFlow\PurchaseContext;
 use Eccube\Service\PurchaseFlow\PurchaseProcessor;
 use Eccube\Service\TaxRuleService;
-use Plugin\Coupon44\Entity\Coupon;
 use Plugin\Coupon44\Entity\CouponOrder;
 use Plugin\Coupon44\Repository\CouponOrderRepository;
 use Plugin\Coupon44\Repository\CouponRepository;

--- a/Tests/Service/PurchaseFlow/Processor/CouponStateProcessorTest.php
+++ b/Tests/Service/PurchaseFlow/Processor/CouponStateProcessorTest.php
@@ -35,6 +35,7 @@ use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
  *
  * キャンセル遷移を含む受注編集の Web テスト (OrderControllerTest::testOrderEditWithCouponCancel)
  * は本体のテストハーネス制約 (EC-CUBE/ec-cube#7016) で実行できないため, 本テストで代替する。
+ * 画面を通したキャンセル遷移は E2E (e2e/admin_order_cancel_coupon.test.ts) で検証する。
  */
 class CouponStateProcessorTest extends EccubeTestCase
 {

--- a/Tests/Web/Admin/OrderControllerTest.php
+++ b/Tests/Web/Admin/OrderControllerTest.php
@@ -198,8 +198,10 @@ class OrderControllerTest extends AbstractEditControllerTestCase
         // TODO 本体側で DAMA DoctrineTestBundle と StockReduceProcessor の悲観ロックの
         //      非互換が解消され次第、markTestSkipped を外して再有効化する。
         //      追跡: EC-CUBE/ec-cube#7016
+        //      キャンセル遷移そのものは E2E (e2e/admin_order_cancel_coupon.test.ts) で検証する。
+        //      TransactionListener が有効な実リクエストで動くため本制約を受けない。
         //      キャンセル時のクーポン枚数戻しは Web リクエストを介さないユニットテスト
-        //      (Tests/Service/PurchaseFlow/Processor/CouponStateProcessorTest) で代替している。
+        //      (Tests/Service/PurchaseFlow/Processor/CouponStateProcessorTest) でも代替している。
         $this->markTestSkipped('本体 StockReduceProcessor の悲観ロックが DAMA テストトランザクションと非互換のためスキップ（プラグイン非依存）');
 
         // @phpstan-ignore deadCode.unreachable (markTestSkipped 以降は再有効化用に残した到達不能コード)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,6 +5,7 @@ services:
     #    （eccube:composer:require はパッケージ API が必要なため path プラグインでは使えない）
     #    PharData は先頭の "./" エントリで失敗するため、プラグインディレクトリ内で
     #    "./*" を対象に tar 化する（ドットファイル/docker 関連は除外される）
+    #    E2E (Playwright) の資産はプラグインの配布物ではないため除外する
     # 3. プラグインを有効化してから Apache を起動
     #    eccube:plugin:enable は内部でキャッシュ再生成を行うが、その直後の cache:clear
     #    だけではプラグイン由来の TemplateEvent が確定しない
@@ -15,7 +16,9 @@ services:
       docker-php-entrypoint ls &&
       ( cd /var/www/plugin && tar czf /tmp/Coupon44.tar.gz
       --exclude='./dockerbuild' --exclude='./docker-compose*'
-      --exclude='./var' --exclude='./vendor' --exclude='./node_modules' ./* ) &&
+      --exclude='./var' --exclude='./vendor' --exclude='./node_modules'
+      --exclude='./e2e' --exclude='./playwright.config.ts' --exclude='./playwright-report'
+      --exclude='./test-results' --exclude='./package.json' --exclude='./package-lock.json' ./* ) &&
       bin/console eccube:plugin:install --code=Coupon44 --path=/tmp/Coupon44.tar.gz --if-not-exists &&
       bin/console eccube:plugin:enable --code=Coupon44 &&
       bin/console cache:clear &&

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,9 @@
 services:
   ec-cube:
     # 1. EC-CUBE 本体を初回起動時に自動インストール（installer-scripts で fixtures も投入）
+    #    インストール直後は var/build のコンパイル済みコンテナが未完成なことがあり、そのまま
+    #    bin/console を実行すると getRuntimeCachePoolClearListenerService.php が無いと言われて
+    #    失敗するため、eccube:cache:build でコンテナを確定させてから後続を実行する
     # 2. マウントしたプラグインを tar 化し eccube:plugin:install でインストール
     #    （eccube:composer:require はパッケージ API が必要なため path プラグインでは使えない）
     #    PharData は先頭の "./" エントリで失敗するため、プラグインディレクトリ内で
@@ -11,9 +14,18 @@ services:
     #    だけではプラグイン由来の TemplateEvent が確定しない
     #    （購入画面・マイページ・受注編集画面にクーポン項目が描画されない）。enable とは
     #    別パスで cache:clear をもう一度実行すると確定するため、cache:clear を 2 回流す。
+    # 4. cache:clear 後にウォームアップを明示的に実行する。
+    #    var/cache/dev/htmlpurifier は cache:warmup で生成されるが、cache:clear だけでは
+    #    残らないことがあり、無いと Block/news.twig のレンダリングが
+    #    "Base directory .../htmlpurifier does not exist" で 500 になる。
+    # 5. 上記の bin/console は root で実行するため、生成物 (var/build 等) が root 所有になる。
+    #    Apache は www-data で動き、Doctrine は var/build/dev/doctrine/orm/Proxies に
+    #    プロキシを書き出すため、所有者を www-data に戻してから起動する。
+    #    （戻さないと ORMInvalidArgumentException "proxy directory must be writable" で 500）
     entrypoint: >
       /bin/bash -c "
       docker-php-entrypoint ls &&
+      bin/console eccube:cache:build &&
       ( cd /var/www/plugin && tar czf /tmp/Coupon44.tar.gz
       --exclude='./dockerbuild' --exclude='./docker-compose*'
       --exclude='./var' --exclude='./vendor' --exclude='./node_modules'
@@ -23,6 +35,8 @@ services:
       bin/console eccube:plugin:enable --code=Coupon44 &&
       bin/console cache:clear &&
       bin/console cache:clear &&
+      bin/console cache:warmup &&
+      chown -R www-data: var app html &&
       apache2-foreground
       "
     environment:

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -18,7 +18,11 @@ services:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_USER: dbuser
       MYSQL_PASSWORD: secret
-      MYSQL_DATABASE: eccubedb
+      # MYSQL_DATABASE は指定しない。データベースが既にあると本体イメージの entrypoint が
+      # 実行する installer-scripts の doctrine:database:create が
+      # "Can't create database 'eccubedb'; database exists" で失敗するため、
+      # データベースは EC-CUBE のインストーラに作らせる
+      # (dbuser には grant_to_dbuser.sql で CREATE 権限を与えている)
     volumes:
       - mysql-database:/var/lib/mysql
       - ./dockerbuild/grant_to_dbuser.sql:/docker-entrypoint-initdb.d/grant_to_dbuser.sql

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -35,3 +35,6 @@ services:
       interval: 3s
       timeout: 3s
       retries: 3
+      # 初期化 (ユーザー作成・init スクリプト) に数十秒かかることがあり、
+      # start_period が無いと CI で unhealthy 扱いになって起動に失敗する
+      start_period: 60s

--- a/docker-compose.pgsql.yml
+++ b/docker-compose.pgsql.yml
@@ -17,7 +17,9 @@ services:
     environment:
       POSTGRES_USER: dbuser
       POSTGRES_PASSWORD: secret
-      POSTGRES_DB: eccubedb
+      # POSTGRES_DB は指定しない。データベースが既にあると本体イメージの entrypoint が
+      # 実行する installer-scripts の doctrine:database:create が失敗するため、
+      # データベースは EC-CUBE のインストーラに作らせる (dbuser はスーパーユーザー)
       # postgres:18 で PGDATA のデフォルトレイアウトが変わり、従来の volume
       # マウント先 (/var/lib/postgresql/data) だけでは起動に失敗するため明示する
       PGDATA: /var/lib/postgresql/data

--- a/docker-compose.pgsql.yml
+++ b/docker-compose.pgsql.yml
@@ -34,3 +34,5 @@ services:
       interval: 3s
       timeout: 3s
       retries: 3
+      # 初期化に時間がかかると unhealthy 扱いになるため猶予を設ける
+      start_period: 60s

--- a/e2e/admin_order_cancel_coupon.test.ts
+++ b/e2e/admin_order_cancel_coupon.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from './fixtures';
+
+import {
+  adminLogin,
+  adminLogout,
+  applyCoupon,
+  createCoupon,
+  couponRemaining,
+  goToShoppingAsGuest,
+  latestOrderEditUrl,
+  placeOrder,
+} from './helpers';
+
+/**
+ * 受注ステータスを「注文取消し」(OrderStatus::CANCEL) へ変更したときのクーポンの挙動を確認する.
+ *
+ * このケースは PHPUnit の Web テストでは検証できない。
+ * キャンセル遷移では本体の StockReduceProcessor が在庫を戻すために
+ * EntityManager::lock(PESSIMISTIC_WRITE) を行うが, APP_ENV=test では
+ * dama/doctrine-test-bundle のトランザクションが DBAL Connection 上では
+ * 開いていないため TransactionRequiredException になる
+ * (Tests/Web/Admin/OrderControllerTest::testOrderEditWithCouponCancel は
+ *  そのためスキップしている)。
+ *
+ * E2E は prod と同じく TransactionListener が有効な環境で実リクエストを送るため,
+ * この制約を受けずにキャンセル遷移を検証できる。
+ *
+ * @see https://github.com/EC-CUBE/ec-cube/issues/7016
+ */
+test('受注をキャンセルするとクーポンが戻り, 受注編集画面に案内が表示される', async ({ page }) => {
+  const couponCd = `E2E${Date.now()}`;
+  const couponRelease = 10;
+
+  await adminLogin(page);
+  await createCoupon(page, { couponCd, discountPrice: 1000, couponRelease });
+  await adminLogout(page);
+
+  await goToShoppingAsGuest(page);
+  await applyCoupon(page, couponCd);
+  await placeOrder(page);
+
+  await adminLogin(page);
+  expect(await couponRemaining(page, couponCd)).toBe(couponRelease - 1);
+
+  const orderEditUrl = await latestOrderEditUrl(page);
+  const response = await page.goto(orderEditUrl);
+  expect(response?.status()).toBe(200);
+  await expect(page.locator('#coupon')).toContainText(couponCd);
+
+  // 受注ステータスを「注文取消し」(OrderStatus::CANCEL = 3) に変更して登録する
+  await page.locator('#order_OrderStatus').selectOption('3');
+  await page.getByRole('button', { name: '登録' }).first().click();
+  await expect(page).toHaveURL(orderEditUrl);
+
+  // 在庫を戻す StockReduceProcessor が悲観ロックを取るため, ここが 500 になっていないこと
+  await expect(page.locator('body')).not.toContainText('システムエラーが発生しました');
+  await expect(page.locator('#order_OrderStatus')).toHaveValue('3');
+
+  // キャンセルされたためクーポンが適用されていない旨が表示される
+  await expect(page.locator('#coupon')).toContainText('注文がキャンセルされたため、クーポンが適用されていません。');
+
+  // クーポンは未使用に戻る
+  expect(await couponRemaining(page, couponCd)).toBe(couponRelease);
+});

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,28 @@
+import { test as base } from '@playwright/test';
+
+/**
+ * Coupon44 E2E 用の test フィクスチャ.
+ *
+ * docker-compose.dev.yml の EC-CUBE は APP_DEBUG=1 で動くため、画面下部に Symfony の
+ * Web デバッグツールバーが固定表示される。フォーム末尾の「登録」ボタンなどがツールバーに
+ * 隠れてクリックを奪われるので、E2E の間は CSS で非表示にする。
+ */
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    await page.addInitScript(() => {
+      const hideToolbar = () => {
+        const style = document.createElement('style');
+        style.textContent = '.sf-toolbar, .sf-minitoolbar { display: none !important; }';
+        document.head?.appendChild(style);
+      };
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', hideToolbar);
+      } else {
+        hideToolbar();
+      }
+    });
+    await use(page);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/e2e/front_coupon.test.ts
+++ b/e2e/front_coupon.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from './fixtures';
+
+import {
+  adminLogin,
+  adminLogout,
+  applyCoupon,
+  createCoupon,
+  couponRemaining,
+  goToShoppingAsGuest,
+  placeOrder,
+  shoppingPaymentTotal,
+} from './helpers';
+
+/**
+ * 購入フローでクーポンコードによる値引きが適用されることを確認する.
+ *
+ * PHPUnit の Web テスト (Tests/Web/CouponControllerTest) と重なる部分もあるが, こちらは
+ * 実ブラウザ・実リクエストで JS (クーポン入力画面への遷移) まで含めて検証する。
+ */
+test('クーポンコードを適用すると値引きされ, 発行枚数が減る', async ({ page }) => {
+  const couponCd = `E2E${Date.now()}`;
+  const couponName = `E2E クーポン ${couponCd}`;
+  const discount = 1000;
+  const couponRelease = 10;
+
+  await adminLogin(page);
+  await createCoupon(page, { couponCd, couponName, discountPrice: discount, couponRelease });
+  expect(await couponRemaining(page, couponCd)).toBe(couponRelease);
+  await adminLogout(page);
+
+  await goToShoppingAsGuest(page);
+  const paymentTotalBeforeCoupon = await shoppingPaymentTotal(page);
+
+  await applyCoupon(page, couponCd);
+  await expect(page.locator('#coupon')).toContainText(`クーポンコード ${couponCd} を利用しています。`);
+
+  // 値引き明細 (商品名 = クーポン名) が追加され, お支払い合計が値引き額だけ下がる
+  await expect(page.locator('.ec-orderRole')).toContainText(couponName);
+  expect(await shoppingPaymentTotal(page)).toBe(paymentTotalBeforeCoupon - discount);
+
+  await placeOrder(page);
+
+  // 利用済みになった分, 残発行枚数が 1 枚減る
+  await adminLogin(page);
+  expect(await couponRemaining(page, couponCd)).toBe(couponRelease - 1);
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,157 @@
+import { expect, type Page } from '@playwright/test';
+
+/** 管理画面にログインする */
+export async function adminLogin(page: Page): Promise<void> {
+  await page.goto('/admin/login');
+  await page.fill('input[name="login_id"]', 'admin');
+  await page.fill('input[name="password"]', 'password');
+  await page.locator('button[type="submit"]').click();
+  await expect(page).toHaveURL('/admin/');
+}
+
+/** 管理画面からログアウトする */
+export async function adminLogout(page: Page): Promise<void> {
+  await page.goto('/admin/logout');
+  await expect(page).toHaveURL(/\/admin\/login/);
+}
+
+function formatDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+export type CouponOptions = {
+  couponCd: string;
+  couponName?: string;
+  discountPrice: number;
+  couponRelease?: number;
+};
+
+/**
+ * 管理画面からクーポンを登録する.
+ *
+ * 対象商品は「全商品」, 利用制限は「なし」(ゲストでも利用できる), 値引き種別は「値引き額」で固定。
+ */
+export async function createCoupon(page: Page, options: CouponOptions): Promise<void> {
+  const { couponCd, discountPrice } = options;
+  const couponName = options.couponName ?? `E2E クーポン ${couponCd}`;
+  const couponRelease = options.couponRelease ?? 10;
+
+  await page.goto('/admin/plugin/coupon/new');
+
+  await page.fill('#coupon_coupon_cd', couponCd);
+  await page.fill('#coupon_coupon_name', couponName);
+  // 対象商品: 全商品 (Coupon::ALL) — 商品/カテゴリ明細が不要になる
+  await page.check('#coupon_coupon_type_2');
+  // 利用制限: なし (ゲスト購入でも利用できる)
+  await page.check('#coupon_coupon_member_1');
+  // 値引き種別: 値引き額
+  await page.check('#coupon_discount_type_0');
+  await page.fill('#coupon_discount_price', String(discountPrice));
+  await page.fill('#coupon_coupon_release', String(couponRelease));
+
+  const today = new Date();
+  const nextMonth = new Date(today.getTime());
+  nextMonth.setMonth(nextMonth.getMonth() + 1);
+  await page.fill('#coupon_available_from_date', formatDate(today));
+  await page.fill('#coupon_available_to_date', formatDate(nextMonth));
+
+  await page.locator('button:has-text("登録")').first().click();
+  await expect(page).toHaveURL('/admin/plugin/coupon');
+  await expect(page.locator('body')).toContainText(couponCd);
+}
+
+/**
+ * クーポン一覧から残発行枚数 (plg_coupon.coupon_use_time) を取得する.
+ *
+ * 一覧の残発行枚数カラムは「残発行枚数 / 発行枚数」形式で, admin/index.twig の 7 列目。
+ */
+export async function couponRemaining(page: Page, couponCd: string): Promise<number> {
+  await page.goto('/admin/plugin/coupon');
+  const row = page.locator('tbody tr', { hasText: couponCd }).first();
+  const text = (await row.locator('td').nth(6).innerText()).trim();
+  const matched = text.match(/^([\d,]+)\s*\/\s*([\d,]+)$/);
+  expect(matched, `残発行枚数が取得できない: ${text}`).toBeTruthy();
+  return Number((matched as RegExpMatchArray)[1].replace(/,/g, ''));
+}
+
+/** ゲストでカートに商品を入れ, 購入手続き画面 (/shopping) まで進む */
+export async function goToShoppingAsGuest(page: Page): Promise<void> {
+  await page.goto('/');
+
+  await page.getByRole('link', { name: '新入荷' }).click();
+  await expect(page).toHaveURL('/products/list?category_id=2');
+  await page
+    .locator('li:has-text("チェリーアイスサンド")')
+    .getByRole('button', { name: 'カートに入れる' })
+    .first()
+    .click();
+
+  // EC-CUBE 4.4 のカートボタンは AJAX リクエストを送るため完了を待ってから遷移する
+  await page.waitForLoadState('networkidle');
+  await page.goto('/cart');
+
+  await page.getByRole('link', { name: 'レジに進む' }).click();
+  await expect(page).toHaveURL('/shopping/login');
+
+  await page.getByRole('link', { name: 'ゲスト購入' }).click();
+  await expect(page).toHaveURL('/shopping/nonmember');
+
+  await page.getByPlaceholder('姓').fill('石');
+  await page.getByPlaceholder('名', { exact: true }).fill('九部');
+  await page.getByPlaceholder('セイ').fill('イーシー');
+  await page.getByPlaceholder('メイ').fill('キューブ');
+  await page.getByLabel('会社名').fill('イーシーキューブ');
+  await page.getByPlaceholder('例：5300001').fill('5430001');
+  await page.locator('select[name="nonmember\\[address\\]\\[pref\\]"]').selectOption('1');
+  await page.getByPlaceholder('市区町村名(例：大阪市北区)').fill('大阪市北区');
+  await page.getByPlaceholder('番地・ビル名(例：西梅田1丁目6-8)').fill('1');
+  await page.getByPlaceholder('例：11122223333').fill('0633334444');
+  await page.getByPlaceholder('例：ec-cube@example.com').fill('user@example.com');
+  await page.getByPlaceholder('確認のためもう一度入力してください').fill('user@example.com');
+
+  await page.getByRole('button', { name: '次へ' }).click();
+  await expect(page).toHaveURL('/shopping');
+}
+
+/** 購入手続き画面からクーポンコードを入力して適用する */
+export async function applyCoupon(page: Page, couponCd: string): Promise<void> {
+  // クーポン欄の「クーポンを変更する」は ajax 後にクーポン入力画面へ遷移する
+  await page.locator('#coupon_button').click();
+  await expect(page).toHaveURL('/plugin/coupon/shopping/shopping_coupon');
+
+  await page.check('#coupon_use_coupon_use_1');
+  await page.fill('#coupon_use_coupon_cd', couponCd);
+  await page.getByRole('button', { name: '登録' }).click();
+  await expect(page).toHaveURL('/shopping');
+}
+
+/** 購入手続き画面から注文を確定する */
+export async function placeOrder(page: Page): Promise<void> {
+  await page.getByRole('button', { name: '確認する' }).click();
+  await expect(page).toHaveURL('/shopping/confirm');
+
+  await page.getByRole('button', { name: '注文する' }).click();
+  await expect(page).toHaveURL('/shopping/complete');
+}
+
+/** 購入手続き画面 (/shopping) の「お支払い合計」を取得する */
+export async function shoppingPaymentTotal(page: Page): Promise<number> {
+  const text = await page.locator('.ec-totalBox__paymentTotal .ec-totalBox__price').first().innerText();
+  const matched = text.match(/([\d,]+)/);
+  expect(matched, `お支払い合計が取得できない: ${text}`).toBeTruthy();
+  return Number((matched as RegExpMatchArray)[1].replace(/,/g, ''));
+}
+
+/** 受注一覧から最新の受注の編集画面 URL を取得する */
+export async function latestOrderEditUrl(page: Page): Promise<string> {
+  await page.goto('/admin/order');
+  const href = await page
+    .locator('a[href*="/admin/order/"][href*="/edit"]')
+    .first()
+    .getAttribute('href');
+  expect(href, '受注編集リンクが見つからない').toBeTruthy();
+  return href as string;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,60 @@
+{
+  "name": "ec-cube-coupon44",
+  "version": "4.4.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ec-cube-coupon44",
+      "version": "4.4.0",
+      "devDependencies": {
+        "@playwright/test": "^1.63.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ec-cube-coupon44",
+  "version": "4.4.0",
+  "private": true,
+  "description": "E2E tests (Playwright) for EC-CUBE 4.4 Coupon plugin",
+  "scripts": {
+    "test:e2e": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.63.0"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Coupon44 の E2E テスト設定.
+ *
+ * docker compose (docker-compose.yml + docker-compose.dev.yml) で起動した
+ * EC-CUBE (プラグイン有効化済み) に対して実行する。
+ *
+ * @see https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 60 * 1000,
+  expect: {
+    timeout: 10 * 1000,
+  },
+  /*
+   * 1 つの EC-CUBE インスタンスを共有し, クーポンの発行枚数や受注ステータスという
+   * グローバルな状態を書き換えるため, 並列実行はしない。
+   */
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    /* docker-compose.yml が 8080:80 を公開する。dev 環境は HTTP でログインできるよう
+       dockerbuild/dev-framework.yaml で Cookie 設定を上書きしている。 */
+    baseURL: process.env.ECCUBE_BASE_URL ?? 'http://localhost:8080',
+    ignoreHTTPSErrors: true,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    locale: 'ja-JP',
+    timezoneId: 'Asia/Tokyo',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});


### PR DESCRIPTION
close #202

## 概要

受注ステータスを「注文取消し」へ遷移させる検証は、本体 `StockReduceProcessor` の悲観ロック (`EntityManager::lock(PESSIMISTIC_WRITE)`) と dama/doctrine-test-bundle の非互換により `APP_ENV=test` の Web テストでは書けない (EC-CUBE/ec-cube#7016)。本体 issue で示された方針どおり、E2E (Playwright) を導入してこのケースを検証できるようにする。

E2E は prod と同じく `TransactionListener` が有効な環境で実リクエストを送るため、`TransactionRequiredException` にならずキャンセル遷移を検証できる。

## 変更内容

### E2E の導入

4.4 ブランチで既に E2E 資産を持つ [sample-payment-plugin](https://github.com/EC-CUBE/sample-payment-plugin) と同じく、本リポジトリの `docker compose` で起動した EC-CUBE (プラグイン有効化済み) に対して Playwright を実行する。

- `package.json` / `package-lock.json` / `playwright.config.ts`
- `e2e/helpers.ts`: 管理ログイン・クーポン登録・ゲスト購入などの共通操作
- `e2e/fixtures.ts`: `APP_DEBUG=1` の Symfony Web デバッグツールバーがボタンのクリックを奪うため、E2E の間だけ CSS で非表示にする

1 つの EC-CUBE インスタンスを共有し、クーポンの残発行枚数や受注ステータスというグローバルな状態を書き換えるため、`workers: 1` / `fullyParallel: false` で直列実行する。クーポンコードはテストごとに一意にしている。

### spec

| spec | 内容 |
|---|---|
| `e2e/admin_order_cancel_coupon.test.ts` | 受注編集画面で受注ステータスを「注文取消し」に変更しても 500 にならず、クーポン未適用の案内が表示され、クーポンの残発行枚数が戻る (**本 PR の本題**) |
| `e2e/front_coupon.test.ts` | 購入フローでクーポンコードを適用するとお支払い合計が値引きされ、購入後に残発行枚数が 1 枚減る |

### CI

`.github/workflows/playwright.yml` を追加。既存の PHPUnit の `ci.yml` (`APP_ENV=test`) とは別ワークフローなので併存する。

- matrix: PHP `8.2-apache-4.4` / `8.5-apache-4.4` × DB `sqlite3` / `mysql` / `pgsql`
  - PHP は `ci.yml` が全バージョンを網羅しているため E2E は下限と上限のみ。DB はキャンセル遷移が悲観ロックを伴い差異が出るため 3 種類とも実行する
- 失敗時は `docker compose logs ec-cube` を出力し、レポートを artifact にアップロードする

### その他

- PHPUnit 側の `testOrderEditWithCouponCancel` のスキップは維持したまま、コメントから E2E を参照する
- E2E の資産 (`e2e/` `playwright.config.ts` `package*.json`) はプラグインの配布物ではないため、`docker-compose.dev.yml` と `ci.yml` の tar から除外する
- `CLAUDE.md` に E2E の実行手順と「受注ステータス遷移を伴う検証は E2E に書く」方針を追記


## 追加で同梱した修正

E2E を CI で回した結果として見つかった、本 PR 無しでは気づけなかった不具合も同梱しています。

### dev 環境が最新の 4.4 イメージで起動できていなかった

`docker-compose.yml` の `pull_policy: missing` により手元では古いイメージが使われており、常に最新を pull する CI との差で顕在化しました。

- installer 直後は `var/build` のコンパイル済みコンテナが未完成なことがあり、`eccube:plugin:install` が `getRuntimeCachePoolClearListenerService.php` 不在で落ちる → `eccube:cache:build` を先に実行
- `cache:clear` だけでは `var/cache/dev/htmlpurifier` が残らず、`Block/news.twig` が `Base directory ... does not exist` で 500 → `cache:warmup` を明示実行
- entrypoint の `bin/console` は root 実行のため `var/build` が root 所有になり、www-data の Apache が Doctrine プロキシを書けず 500 (`ORMInvalidArgumentException: proxy directory must be writable`) → 起動前に `chown -R www-data: var app html`
- mysql/pgsql はコンテナ側でデータベースを作ると installer-scripts の `doctrine:database:create` が `database exists` で失敗 → データベースは EC-CUBE のインストーラに作らせる
- mysql / postgres の healthcheck に `start_period: 60s` を追加 (初期化が遅いと unhealthy 扱いになり `dependency failed to start` になっていた)

### Rector がバージョン別セットの撤去で動かなくなっていた

`Run Rector` が `Undefined constant Rector\Symfony\Set\SymfonySetList::SYMFONY_74` で失敗していました。rector 2.6.2 でバージョン別のセット定数が撤去されたためで、本体は EC-CUBE/ec-cube#7099 で対応済み、プラグイン側が未対応でした。

- `SymfonySetList::SYMFONY_74` → `COMPOSER_BASED`、`DoctrineSetList::DOCTRINE_DBAL_30` → `COMPOSER_BASED`
- 上記で検出されるようになった未使用 `use` を除去
- composer-based セットは `vendor/composer/installed.json` を読むため、rector は本体のルートで実行する必要がある (`CLAUDE.md` のコマンドを修正)

### PHPStan の既存の指摘

Rector が先に落ちていて表面化していなかった `booleanAnd.rightAlwaysTrue` を修正しました (`CouponShoppingController`)。`$Coupon` が null の場合は上で `$error = true` にしているため、`!$error && $Coupon` の右辺は常に true です。

### スタック PR で CI が起動しなかった

`pull_request` の `branches` フィルタは base ブランチ名で判定されますが、`'*'` はスラッシュにマッチしません。base を `feature/...` にしたスタック PR ではワークフローが一切起動しなかったため、`'**'` に変更しました。

## 動作確認

sqlite3 / mysql / pgsql の 3 構成で、`docker compose down -v` からのクリーンインストールで 2 spec とも通ることを確認しています。

```
########## sqlite3 ##########   2 passed
########## mysql ##########     2 passed
########## pgsql ##########     2 passed
```

CI も E2E 6 構成 (PHP 8.2/8.5 × sqlite3/mysql/pgsql)、PHPUnit 8 構成、Static Analysis すべて green です。

## 依存

#199 の上に積んだスタック PR です (base: `feature/remove-order-item-tax-rule-id`)。#199 が 4.4 にマージされると base は自動的に 4.4 へ貼り替わります。#199 には CI の実行履歴がないため、本 PR の CI がその検証も兼ねています。

Refs EC-CUBE/ec-cube#7016

🤖 Generated with [Claude Code](https://claude.com/claude-code)
